### PR TITLE
feat: added tower authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,44 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
+name = "async-compression"
+version = "0.4.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98ec5f6c2f8bc326c994cb9e241cc257ddaba9afa8555a43cffbb5dd86efaa37"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "async-trait"
@@ -18,6 +52,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "base64"
@@ -44,16 +84,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "bytes"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+
+[[package]]
+name = "cc"
+version = "1.2.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a0aeaff4ff1a90589618835a598e545176939b97874f7abc7851caa0618f203"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f7ac3e5b97fdce45e8922fb05cae2c37f7bbd63d30dd94821dacfd8f3f2bf2"
+dependencies = [
+ "brotli",
+ "compression-core",
+ "flate2",
+ "memchr",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "config"
@@ -137,6 +242,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -265,10 +379,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
+
+[[package]]
+name = "flate2"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -301,6 +477,25 @@ dependencies = [
  "libc",
  "r-efi",
  "wasip2",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -340,6 +535,103 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,10 +642,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "json5"
@@ -424,6 +752,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,19 +773,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "mongodb-atlas-cli"
 version = "0.0.1"
 dependencies = [
  "base64",
+ "bytes",
  "config",
  "dirs",
  "hex",
+ "http",
+ "http-body-util",
+ "hyper-util",
  "keyring",
  "pretty_assertions",
  "serde",
  "tempfile",
  "thiserror",
+ "tokio",
  "toml",
+ "tower",
+ "tower-http",
 ]
 
 [[package]]
@@ -474,10 +855,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
@@ -523,6 +933,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,6 +983,15 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "redox_users"
@@ -611,10 +1042,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
@@ -728,6 +1171,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,6 +1224,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "tempfile"
@@ -781,6 +1274,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,6 +1354,88 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
 
 [[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "async-compression",
+ "base64",
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "iri-string",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,6 +1454,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,10 +1472,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "uuid"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+dependencies = [
+ "getrandom 0.3.4",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -868,6 +1510,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1082,4 +1769,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,6 +31,12 @@ checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
 ]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "arraydeque"
@@ -58,6 +73,28 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.37.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "base64"
@@ -139,6 +176,15 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "compression-codecs"
@@ -307,6 +353,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest_auth"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3054f4e81d395e50822796c5e99ca522e6ba7be98947d6d4b0e5e61640bdb894"
+dependencies = [
+ "digest",
+ "hex",
+ "md-5",
+ "rand",
+ "sha2",
+]
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,6 +387,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dlv-list"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +405,18 @@ checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
 dependencies = [
  "const-random",
 ]
+
+[[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "encoding_rs"
@@ -405,6 +487,27 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "fragile"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -608,6 +711,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,6 +751,108 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -711,6 +935,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -752,6 +982,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -765,6 +1001,25 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -810,26 +1065,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "mongodb-atlas-cli"
 version = "0.0.1"
 dependencies = [
  "base64",
  "bytes",
  "config",
+ "digest_auth",
  "dirs",
  "hex",
  "http",
+ "http-body",
  "http-body-util",
+ "hyper-rustls",
  "hyper-util",
  "keyring",
+ "mockall",
  "pretty_assertions",
+ "rustls",
  "serde",
+ "serde_json",
  "tempfile",
  "thiserror",
  "tokio",
  "toml",
  "tower",
  "tower-http",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -837,6 +1136,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "option-ext"
@@ -951,6 +1256,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -985,6 +1334,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1002,6 +1381,37 @@ dependencies = [
  "getrandom 0.2.16",
  "libredox",
  "thiserror",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1042,6 +1452,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+dependencies = [
+ "aws-lc-rs",
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.5.1",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,6 +1511,15 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1171,6 +1639,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1215,6 +1692,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1232,6 +1721,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1243,6 +1743,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
@@ -1265,12 +1771,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -1299,6 +1824,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -1417,7 +1952,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1427,6 +1974,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1472,6 +2049,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "uuid"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1481,6 +2082,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
@@ -1558,10 +2165,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1735,6 +2360,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
 name = "yaml-rust2"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1752,6 +2383,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1765,6 +2460,39 @@ name = "zeroize_derive"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,14 +14,21 @@ exclude = ["cliff.toml"]
 
 [dependencies]
 base64 = "0.22.1"
+bytes = "1.11.0"
 config = "0.15.19"
 dirs = "6.0.0"
 hex = "0.4.3"
+http = "1.4.0"
+http-body-util = "0.1.3"
+hyper-util = { version = "0.1.19", features = ["client-legacy", "http1", "http2", "client-proxy", "tokio"] }
 keyring = { version = "3.6.3", features = ["apple-native", "windows-native", "linux-native-sync-persistent"] }
 serde = { version = "1.0.228", features = ["derive"] }
 thiserror = "2.0.17"
 toml = { version = "0.9.8", features = ["preserve_order"] }
+tower = "0.5.2"
+tower-http = { version = "0.6.8", features = ["full"] }
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"
 tempfile = "3.23.0"
+tokio = { version = "1.49.0", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,19 +16,29 @@ exclude = ["cliff.toml"]
 base64 = "0.22.1"
 bytes = "1.11.0"
 config = "0.15.19"
+digest_auth = "0.3"
 dirs = "6.0.0"
 hex = "0.4.3"
 http = "1.4.0"
+http-body = "1.0.1"
 http-body-util = "0.1.3"
+hyper-rustls = { version = "0.27", features = ["ring", "http1", "http2", "webpki-roots"] }
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 hyper-util = { version = "0.1.19", features = ["client-legacy", "http1", "http2", "client-proxy", "tokio"] }
 keyring = { version = "3.6.3", features = ["apple-native", "windows-native", "linux-native-sync-persistent"] }
 serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1"
 thiserror = "2.0.17"
+tokio = { version = "1", features = ["sync"] }
 toml = { version = "0.9.8", features = ["preserve_order"] }
 tower = "0.5.2"
 tower-http = { version = "0.6.8", features = ["full"] }
+tracing = "0.1"
+url = "2.5.8"
 
 [dev-dependencies]
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+mockall = "0.13"
 pretty_assertions = "1.4.1"
 tempfile = "3.23.0"
-tokio = { version = "1.49.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }

--- a/examples/use_client.rs
+++ b/examples/use_client.rs
@@ -103,7 +103,7 @@ async fn main() {
     // Step 4: Make an authenticated request.
     //
     // The URI is built from the config's base URL so that dev/staging
-    // environments (e.g., cloud-dev.mongodb.com) are supported automatically.
+    // environments are supported automatically.
     let uri = format!("{}/api/atlas/v2/groups", cfg.base_url());
     println!("\nRequesting: {uri}");
 

--- a/examples/use_client.rs
+++ b/examples/use_client.rs
@@ -1,0 +1,8 @@
+use mongodb_atlas_cli::client::make_request;
+
+#[tokio::main]
+async fn main() {
+
+    make_request().await;
+
+}

--- a/examples/use_client.rs
+++ b/examples/use_client.rs
@@ -1,8 +1,133 @@
-use mongodb_atlas_cli::client::make_request;
+//! Example: Make an authenticated request to the MongoDB Atlas API.
+//!
+//! This example demonstrates the full setup of an authenticated HTTP client:
+//! 1. Load the CLI config (profile + auth type)
+//! 2. Build an `AuthenticationLayer` from the config (reads secrets automatically)
+//! 3. Compose a Tower service stack with auth + user-agent + decompression
+//! 4. Make a request to the Atlas API
+//!
+//! # Prerequisites
+//!
+//! You need a valid Atlas CLI config at the default config path
+//! (e.g., `~/Library/Application Support/atlascli/config.toml` on macOS)
+//! with credentials stored in the OS keychain or the legacy config file.
+//!
+//! The easiest way to set this up is to run `atlas auth login` with the
+//! official Atlas CLI first, then run this example.
+//!
+//! # Usage
+//!
+//! ```sh
+//! cargo run --example use_client
+//! ```
+
+use bytes::Bytes;
+use http::{HeaderValue, Request, header::USER_AGENT};
+use http_body_util::{BodyExt, Full};
+use hyper_util::{client::legacy::Client, rt::TokioExecutor};
+use tower::{Service, ServiceBuilder, ServiceExt};
+use tower_http::{decompression::DecompressionLayer, set_header::SetRequestHeaderLayer};
+
+use mongodb_atlas_cli::{client::AuthenticationLayer, config, secrets::get_secret_store};
 
 #[tokio::main]
 async fn main() {
+    // Initialize tracing. Control verbosity via the RUST_LOG env var:
+    //   RUST_LOG=debug cargo run --example use_client
+    //   RUST_LOG=mongodb_atlas_cli=debug cargo run --example use_client
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "mongodb_atlas_cli=info".parse().unwrap()),
+        )
+        .init();
 
-    make_request().await;
+    // Install the ring crypto provider for rustls. Both ring and aws-lc-rs
+    // may be compiled in (via transitive dependencies), so an explicit
+    // choice is required.
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("failed to install ring crypto provider");
 
+    let profile = "default";
+    println!("Using profile: {profile}");
+
+    // Step 1: Load the CLI config for the default profile.
+    let cfg = config::load_config(Some(profile)).unwrap_or_else(|e| {
+        eprintln!("Failed to load config: {e}");
+        std::process::exit(1);
+    });
+    println!("Auth type:  {:?}", cfg.auth_type);
+    println!("Service:    {:?}", cfg.service);
+    println!("Base URL:   {}", cfg.base_url());
+
+    // Step 2: Get the secret store and build the authentication layer.
+    //
+    // The secret store reads credentials from the OS keychain (preferred)
+    // or falls back to the legacy config file.
+    let secret_store = get_secret_store().unwrap_or_else(|e| {
+        eprintln!("Failed to open secret store: {e}");
+        std::process::exit(1);
+    });
+
+    // No token acquirer needed — the middleware handles OAuth token refresh
+    // internally by using the inner Tower service.
+    let auth_layer =
+        AuthenticationLayer::from_config(&cfg, profile, secret_store).unwrap_or_else(|e| {
+            eprintln!("Failed to create auth layer: {e}");
+            std::process::exit(1);
+        });
+
+    // Step 3: Build the Tower service stack with an HTTPS-capable client.
+    //
+    // hyper-rustls provides TLS support using rustls (pure Rust, no OpenSSL).
+    // Bundled webpki roots provide Mozilla's trusted certificate authorities.
+    let https_connector = hyper_rustls::HttpsConnectorBuilder::new()
+        .with_webpki_roots()
+        .https_or_http()
+        .enable_http1()
+        .build();
+    let http_client = Client::builder(TokioExecutor::new()).build(https_connector);
+
+    // Layers are applied bottom-to-top: the request flows through
+    // SetRequestHeader → AuthenticationLayer → DecompressionLayer → Client.
+    let mut client = ServiceBuilder::new()
+        .layer(SetRequestHeaderLayer::overriding(
+            USER_AGENT,
+            HeaderValue::from_static("mongodb-atlas-cli-ng/0.0.1"),
+        ))
+        .layer(auth_layer)
+        .layer(DecompressionLayer::new())
+        .service(http_client);
+
+    // Step 4: Make an authenticated request.
+    //
+    // The URI is built from the config's base URL so that dev/staging
+    // environments (e.g., cloud-dev.mongodb.com) are supported automatically.
+    let uri = format!("{}/api/atlas/v2/groups", cfg.base_url());
+    println!("\nRequesting: {uri}");
+
+    let request = Request::builder()
+        .method("GET")
+        .uri(uri)
+        .header("Accept", "application/vnd.atlas.2024-08-05+json")
+        .body(Full::<Bytes>::default())
+        .unwrap();
+
+    match client.ready().await {
+        Ok(ready_client) => match ready_client.call(request).await {
+            Ok(response) => {
+                println!("Status: {}", response.status());
+                let body = response.into_body();
+                let bytes = body.collect().await.unwrap().to_bytes();
+                println!("Body: {}", String::from_utf8_lossy(&bytes));
+            }
+            Err(e) => {
+                eprintln!("Request failed: {e}");
+            }
+        },
+        Err(e) => {
+            eprintln!("Service not ready: {e}");
+        }
+    }
 }

--- a/src/client/auth.rs
+++ b/src/client/auth.rs
@@ -1,0 +1,1507 @@
+//! Tower middleware for adding authentication to HTTP requests.
+//!
+//! This module implements a [`Layer`] and [`Service`] pair that intercepts
+//! outgoing HTTP requests and adds the appropriate authentication headers.
+//! Three authentication methods are supported:
+//!
+//! - **UserAccount** (OAuth2 Bearer + refresh token): Uses an access token
+//!   as a Bearer token, automatically refreshing it when expired.
+//! - **ServiceAccount** (OAuth2 Client Credentials): Acquires an access token
+//!   using client_id/client_secret, caching it until expiry.
+//! - **ApiKeys** (HTTP Digest): Performs the digest challenge-response protocol
+//!   using a public/private key pair.
+//!
+//! # Tower Architecture
+//!
+//! Tower middleware uses two concepts: a [`Layer`] and a [`Service`].
+//!
+//! - A **Layer** is a factory: it takes an inner service and wraps it in a
+//!   new service. Think of it like a constructor for middleware.
+//! - A **Service** is the actual middleware: it intercepts requests, does work
+//!   (in our case, adding auth headers), and forwards them to the inner service.
+//!
+//! ```text
+//! ┌──────────────────────────┐
+//! │   AuthenticationLayer    │  ← Implements Layer<S>: creates Authentication<S>
+//! │ ┌──────────────────────┐ │
+//! │ │  Authentication<S>   │ │  ← Implements Service: adds auth headers
+//! │ │ ┌──────────────────┐ │ │
+//! │ │ │  Inner Service S │ │ │  ← The actual HTTP client
+//! │ │ └──────────────────┘ │ │
+//! │ └──────────────────────┘ │
+//! └──────────────────────────┘
+//! ```
+//!
+//! # Token Acquisition
+//!
+//! When an OAuth2 token needs refreshing, the middleware clones the inner
+//! service and uses it to POST to the token endpoint. This means token
+//! acquisition shares the same transport (TLS, proxies, connection pool)
+//! as regular API requests, and no external token acquirer is needed.
+//!
+//! # Shared State
+//!
+//! All clones of an `Authentication<S>` service share the same token cache
+//! via `Arc<RwLock<AuthState>>`. This means:
+//! - Concurrent requests can read the cached token in parallel (read lock).
+//! - Only token refresh requires exclusive access (write lock).
+//! - A token refreshed by one request is immediately available to all others.
+
+use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use bytes::Bytes;
+use http::header::AUTHORIZATION;
+use http::{HeaderValue, Request, Response};
+use http_body::Body;
+use tokio::sync::RwLock;
+use tower::{Layer, Service};
+use tracing::{debug, info, warn};
+
+use crate::config::{AtlasCLIConfig, AuthType};
+use crate::secrets::{Secret, SecretStore, UserAccount};
+
+use super::digest;
+use super::error::{AuthError, FromConfigError};
+use super::oauth::{self, CachedToken, OAuthTokenResponse};
+
+// ---------------------------------------------------------------------------
+// Auth State
+// ---------------------------------------------------------------------------
+
+/// The mutable authentication state, protected by an [`RwLock`].
+///
+/// This struct is shared (via `Arc<RwLock<...>>`) between all clones of
+/// the [`Authentication`] service. The RwLock allows concurrent reads
+/// of the cached token while serializing writes (token refresh).
+pub struct AuthState {
+    pub(crate) method: AuthMethod,
+}
+
+/// The authentication method and its associated credentials/state.
+///
+/// Each variant carries the data needed for its specific auth flow.
+/// The cached tokens are mutable (updated on refresh), while the
+/// credentials themselves are fixed for the lifetime of the middleware.
+pub enum AuthMethod {
+    /// OAuth2 Bearer authentication with refresh token support.
+    ///
+    /// When the cached access token expires, the middleware uses the inner
+    /// Tower service to POST to the device-flow token endpoint with
+    /// `grant_type=refresh_token`, along with the Atlas CLI `client_id`
+    /// and the required OAuth scopes. The new tokens are persisted to the
+    /// [`SecretStore`].
+    UserAccount {
+        cached_token: Option<CachedToken>,
+        refresh_token: String,
+        token_endpoint: String,
+        /// The Atlas CLI's OAuth2 client_id (public, not a secret).
+        client_id: String,
+        /// Used to persist refreshed tokens so they survive across CLI invocations.
+        secret_store: Box<dyn SecretStore>,
+        /// The CLI profile name, used as the key for the secret store.
+        profile_name: String,
+    },
+
+    /// OAuth2 Bearer authentication using the client credentials grant.
+    ///
+    /// Acquires tokens by POSTing client_id/client_secret to the token
+    /// endpoint. Tokens are cached in memory but not persisted — only
+    /// the credentials themselves are stored in the secret store.
+    ServiceAccount {
+        cached_token: Option<CachedToken>,
+        client_id: String,
+        client_secret: String,
+        token_endpoint: String,
+    },
+
+    /// HTTP Digest authentication using API keys.
+    ///
+    /// Uses the challenge-response protocol: sends a probe request,
+    /// gets a 401 with a nonce, computes a digest hash, and retries.
+    /// No tokens are cached — each request goes through the challenge.
+    ApiKeys {
+        /// The public API key (used as the digest "username").
+        public_key: String,
+        /// The private API key (used as the digest "password").
+        private_key: String,
+    },
+}
+
+/// Lightweight discriminant for [`AuthMethod`].
+///
+/// Used to determine which auth flow to execute without holding a lock
+/// on the full `AuthState` during potentially slow I/O operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AuthMethodKind {
+    UserAccount,
+    ServiceAccount,
+    ApiKeys,
+}
+
+impl AuthMethod {
+    fn kind(&self) -> AuthMethodKind {
+        match self {
+            AuthMethod::UserAccount { .. } => AuthMethodKind::UserAccount,
+            AuthMethod::ServiceAccount { .. } => AuthMethodKind::ServiceAccount,
+            AuthMethod::ApiKeys { .. } => AuthMethodKind::ApiKeys,
+        }
+    }
+
+    /// Returns a reference to the cached token, if one exists.
+    /// ApiKeys auth doesn't use cached tokens, so it always returns None.
+    fn cached_token(&self) -> Option<&CachedToken> {
+        match self {
+            AuthMethod::UserAccount { cached_token, .. }
+            | AuthMethod::ServiceAccount { cached_token, .. } => cached_token.as_ref(),
+            AuthMethod::ApiKeys { .. } => None,
+        }
+    }
+
+    /// Clear the cached token, forcing a refresh on the next request.
+    ///
+    /// Used when the server rejects a token with 401 — the token may have
+    /// expired server-side even though we didn't track its expiry.
+    fn invalidate_token(&mut self) {
+        match self {
+            AuthMethod::UserAccount { cached_token, .. }
+            | AuthMethod::ServiceAccount { cached_token, .. } => {
+                *cached_token = None;
+            }
+            AuthMethod::ApiKeys { .. } => {}
+        }
+    }
+
+    /// Build the token endpoint URL and form-encoded body for a token request.
+    ///
+    /// Returns `(endpoint_url, form_body)`. The form body is ready to be
+    /// sent as the body of a POST request with `Content-Type: application/x-www-form-urlencoded`.
+    ///
+    /// Clones the necessary credential data so the request can be used
+    /// after the lock is released.
+    fn build_token_request(&self) -> Option<(String, String)> {
+        match self {
+            AuthMethod::UserAccount {
+                refresh_token,
+                token_endpoint,
+                client_id,
+                ..
+            } => {
+                let form_body = url::form_urlencoded::Serializer::new(String::new())
+                    .append_pair("client_id", client_id)
+                    .append_pair("refresh_token", refresh_token)
+                    .append_pair("scope", "openid profile offline_access")
+                    .append_pair("grant_type", "refresh_token")
+                    .finish();
+                Some((token_endpoint.clone(), form_body))
+            }
+            AuthMethod::ServiceAccount {
+                client_id,
+                client_secret,
+                token_endpoint,
+                ..
+            } => {
+                let form_body = url::form_urlencoded::Serializer::new(String::new())
+                    .append_pair("grant_type", "client_credentials")
+                    .append_pair("client_id", client_id)
+                    .append_pair("client_secret", client_secret)
+                    .finish();
+                Some((token_endpoint.clone(), form_body))
+            }
+            AuthMethod::ApiKeys { .. } => None,
+        }
+    }
+
+    /// Update the cached token after a successful refresh/acquisition.
+    ///
+    /// For UserAccount, also handles refresh token rotation and persists
+    /// both tokens to the secret store.
+    fn update_token<E>(
+        &mut self,
+        new_token: CachedToken,
+        response: &OAuthTokenResponse,
+    ) -> Result<(), AuthError<E>> {
+        match self {
+            AuthMethod::UserAccount {
+                cached_token,
+                refresh_token,
+                secret_store,
+                profile_name,
+                ..
+            } => {
+                *cached_token = Some(new_token);
+
+                // Handle token rotation: if the server issued a new refresh
+                // token, replace ours. This is a security best practice that
+                // limits the window during which a leaked token is usable.
+                if let Some(new_refresh) = &response.refresh_token {
+                    *refresh_token = new_refresh.clone();
+                }
+
+                // Persist so the refreshed tokens survive across CLI invocations.
+                // Without this, the user would need to re-authenticate every
+                // time they restart the CLI.
+                secret_store.set(
+                    profile_name,
+                    Secret::UserAccount(UserAccount::new(
+                        response.access_token.clone(),
+                        refresh_token.clone(),
+                    )),
+                )?;
+
+                Ok(())
+            }
+            AuthMethod::ServiceAccount { cached_token, .. } => {
+                // Service account tokens are ephemeral — we cache them in
+                // memory for the duration of this CLI session, but don't
+                // persist them. Only the client credentials are stored.
+                *cached_token = Some(new_token);
+                Ok(())
+            }
+            AuthMethod::ApiKeys { .. } => Ok(()),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Layer
+// ---------------------------------------------------------------------------
+
+/// A Tower [`Layer`] that adds authentication to HTTP requests.
+///
+/// Create one using the constructor for your auth type, then apply it
+/// to an HTTP client via [`ServiceBuilder`](tower::ServiceBuilder):
+///
+/// ```rust,ignore
+/// use tower::ServiceBuilder;
+///
+/// let auth_layer = AuthenticationLayer::api_keys(
+///     "my-public-key".into(),
+///     "my-private-key".into(),
+/// );
+///
+/// let client = ServiceBuilder::new()
+///     .layer(auth_layer)
+///     .service(http_client);
+/// ```
+///
+/// Token acquisition for OAuth-based auth types is handled automatically
+/// by the middleware — it uses the inner service to POST to the token endpoint.
+/// No external token acquirer closure is needed.
+///
+/// All services created by this layer share the same token cache.
+#[derive(Clone)]
+pub struct AuthenticationLayer {
+    /// Shared mutable auth state (cached tokens, credentials, etc.).
+    state: Arc<RwLock<AuthState>>,
+}
+
+impl AuthenticationLayer {
+    /// Create a layer for **UserAccount** authentication.
+    ///
+    /// Uses OAuth2 Bearer tokens with refresh token support. When the
+    /// access token expires, the middleware automatically refreshes it
+    /// by POSTing the refresh token to the token endpoint via the inner
+    /// Tower service.
+    ///
+    /// # Arguments
+    ///
+    /// * `access_token` - Current access token from the secret store, if any.
+    ///   Pass `None` to force a refresh on the first request.
+    /// * `refresh_token` - OAuth2 refresh token for acquiring new access tokens.
+    /// * `token_endpoint` - URL of the OAuth2 token endpoint (see
+    ///   [`Service::token_endpoint()`](crate::config::Service::token_endpoint)).
+    /// * `secret_store` - Persists refreshed tokens across CLI invocations.
+    /// * `profile_name` - CLI profile name (key for the secret store).
+    pub fn user_account(
+        access_token: Option<String>,
+        refresh_token: String,
+        token_endpoint: String,
+        client_id: String,
+        secret_store: Box<dyn SecretStore>,
+        profile_name: String,
+    ) -> Self {
+        let cached_token = access_token.map(CachedToken::new);
+
+        AuthenticationLayer {
+            state: Arc::new(RwLock::new(AuthState {
+                method: AuthMethod::UserAccount {
+                    cached_token,
+                    refresh_token,
+                    token_endpoint,
+                    client_id,
+                    secret_store,
+                    profile_name,
+                },
+            })),
+        }
+    }
+
+    /// Create a layer for **ServiceAccount** authentication.
+    ///
+    /// Uses the OAuth2 client credentials grant. The middleware acquires
+    /// a Bearer token by POSTing client_id/client_secret to the token
+    /// endpoint via the inner Tower service, then caches it until expiry.
+    pub fn service_account(
+        client_id: String,
+        client_secret: String,
+        token_endpoint: String,
+    ) -> Self {
+        AuthenticationLayer {
+            state: Arc::new(RwLock::new(AuthState {
+                method: AuthMethod::ServiceAccount {
+                    cached_token: None,
+                    client_id,
+                    client_secret,
+                    token_endpoint,
+                },
+            })),
+        }
+    }
+
+    /// Create a layer for **ApiKeys** (HTTP Digest) authentication.
+    ///
+    /// Uses the HTTP Digest challenge-response protocol. No OAuth tokens
+    /// are involved — each request may trigger a 401 → digest → retry cycle.
+    pub fn api_keys(public_key: String, private_key: String) -> Self {
+        AuthenticationLayer {
+            state: Arc::new(RwLock::new(AuthState {
+                method: AuthMethod::ApiKeys {
+                    public_key,
+                    private_key,
+                },
+            })),
+        }
+    }
+
+    /// Create an authentication layer automatically from the Atlas CLI config.
+    ///
+    /// This is the recommended constructor for CLI usage. It reads the
+    /// `auth_type` from the config, looks up the matching credentials
+    /// from the provided secret store, and wires everything together
+    /// with the correct token endpoint.
+    ///
+    /// The caller is responsible for creating the secret store (via
+    /// [`get_secret_store()`](crate::secrets::get_secret_store) or a
+    /// custom implementation). This keeps `from_config` free of side
+    /// effects and makes it easy to test with a mock store.
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - The loaded CLI config (from [`load_config`](crate::config::load_config)).
+    /// * `profile_name` - The CLI profile name (e.g., `"default"`).
+    /// * `secret_store` - The secret store to read credentials from (and
+    ///   to persist refreshed tokens into for `UserAccount` auth).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FromConfigError`] if:
+    /// - `auth_type` is not set in the config
+    /// - No credentials are found in the secret store for this profile
+    /// - The secret type doesn't match the `auth_type`
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use mongodb_atlas_cli::{
+    ///     config,
+    ///     client::AuthenticationLayer,
+    ///     secrets::get_secret_store,
+    /// };
+    ///
+    /// let config = config::load_config(Some("default")).unwrap();
+    /// let secret_store = get_secret_store().unwrap();
+    ///
+    /// let auth_layer = AuthenticationLayer::from_config(
+    ///     &config,
+    ///     "default",
+    ///     secret_store,
+    /// ).unwrap();
+    /// ```
+    pub fn from_config(
+        config: &AtlasCLIConfig,
+        profile_name: &str,
+        secret_store: Box<dyn SecretStore>,
+    ) -> Result<Self, FromConfigError> {
+        let auth_type = config.auth_type.ok_or(FromConfigError::MissingAuthType)?;
+
+        let secret = secret_store
+            .get(profile_name, auth_type)?
+            .ok_or(FromConfigError::SecretNotFound)?;
+
+        let base_url = config.base_url();
+        let client_id = config.cli_client_id();
+
+        // Token endpoints are derived from the configured base URL so that
+        // dev/staging environments work correctly.
+        let user_account_token_endpoint =
+            format!("{base_url}/api/private/unauth/account/device/token");
+        let service_account_token_endpoint = format!("{base_url}/api/oauth/token");
+
+        match (auth_type, secret) {
+            (AuthType::UserAccount, Secret::UserAccount(ua)) => {
+                debug!(
+                    access_token_len = ua.access_token.len(),
+                    access_token_prefix = &ua.access_token[..ua.access_token.len().min(12)],
+                    refresh_token_len = ua.refresh_token.len(),
+                    refresh_token_prefix = &ua.refresh_token[..ua.refresh_token.len().min(12)],
+                    token_endpoint = %user_account_token_endpoint,
+                    client_id = %client_id,
+                    base_url = %base_url,
+                    "loaded UserAccount credentials from secret store"
+                );
+                Ok(Self::user_account(
+                    Some(ua.access_token),
+                    ua.refresh_token,
+                    user_account_token_endpoint,
+                    client_id.to_string(),
+                    secret_store,
+                    profile_name.to_string(),
+                ))
+            }
+            (AuthType::ServiceAccount, Secret::ServiceAccount(sa)) => Ok(Self::service_account(
+                sa.client_id,
+                sa.client_secret,
+                service_account_token_endpoint,
+            )),
+            (AuthType::ApiKeys, Secret::ApiKeys(keys)) => {
+                Ok(Self::api_keys(keys.public_api_key, keys.private_api_key))
+            }
+            // Config says one auth type, but the stored secret is a different type.
+            _ => Err(FromConfigError::AuthTypeMismatch),
+        }
+    }
+}
+
+/// The Layer trait is Tower's factory pattern: given an inner service S,
+/// produce a new service that wraps it. This is how middleware is composed
+/// in a `ServiceBuilder` chain.
+impl<S> Layer<S> for AuthenticationLayer {
+    type Service = Authentication<S>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        Authentication {
+            inner: service,
+            state: self.state.clone(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+/// Tower [`Service`] that adds authentication headers to HTTP requests.
+///
+/// Wraps an inner HTTP client service and intercepts each request to add
+/// the appropriate auth header before forwarding.
+///
+/// # Clone Semantics
+///
+/// `Authentication<S>` is `Clone` when `S` is `Clone`. All clones share
+/// the same token cache via `Arc<RwLock<...>>`, so a token refreshed by
+/// one clone is immediately available to all others. This is important
+/// because Tower's `ServiceBuilder` and connection pools may clone services.
+#[derive(Clone)]
+pub struct Authentication<S> {
+    inner: S,
+    state: Arc<RwLock<AuthState>>,
+}
+
+/// # Service Implementation
+///
+/// This is the core of the middleware. Key design decisions:
+///
+/// 1. **Boxed future (`Pin<Box<dyn Future>>`)**: We return a boxed future
+///    because `call()` needs to do variable amounts of async work (token
+///    refresh, digest challenge-response) depending on the auth method.
+///    A concrete future type would need to encode all possible paths,
+///    which is impractical.
+///
+/// 2. **Service swap pattern**: Before returning the future, we swap
+///    `self.inner` with a fresh clone. The already-readied service (from
+///    `poll_ready`) moves into the future, while a fresh clone replaces
+///    `self.inner` for the next request. This is a standard Tower pattern
+///    documented in the Tower guides.
+///
+/// 3. **`ReqBody: Clone`**: Required for digest auth, which may need to
+///    resend the same request body after computing the digest. Types like
+///    `Full<Bytes>` are cheaply cloneable (Bytes uses reference counting).
+///
+/// 4. **`ReqBody: From<Bytes>`**: Required for OAuth token refresh. The
+///    middleware constructs a form-encoded POST body and needs to wrap it
+///    in the same body type that the inner service accepts. `Full<Bytes>`
+///    implements `From<Bytes>`.
+///
+/// 5. **Token acquisition via inner service**: When a Bearer token needs
+///    refreshing, the middleware clones the inner service, readies it,
+///    and uses it to POST to the token endpoint. This keeps the transport
+///    consistent and avoids requiring a separate HTTP client.
+impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for Authentication<S>
+where
+    // Clone: needed for the swap pattern, for digest (two calls to inner),
+    // and for token refresh (clone inner to call token endpoint).
+    // Send + 'static: needed because the future is Send and may outlive the call site.
+    S: Service<Request<ReqBody>, Response = Response<ResBody>> + Clone + Send + 'static,
+    S::Future: Send,
+    // Debug: needed to format inner service errors in token refresh error messages.
+    S::Error: Send + fmt::Debug,
+    // Clone: needed for digest auth (replay the request body on retry).
+    // From<Bytes>: needed for constructing token refresh request bodies.
+    ReqBody: From<Bytes> + Clone + Send + 'static,
+    ResBody: Body + Send + 'static,
+    ResBody::Data: Send,
+    // Debug: needed to format body collection errors in token refresh.
+    ResBody::Error: Send + fmt::Debug,
+{
+    type Response = Response<ResBody>;
+    type Error = AuthError<S::Error>;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    /// Delegate readiness to the inner service.
+    ///
+    /// Tower's contract: `poll_ready` must return `Ready(Ok(()))` before
+    /// `call` is invoked. We just forward to the inner service and map
+    /// its error into our `AuthError` type.
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(AuthError::Inner)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        // Clone the shared state — this is a cheap Arc reference increment.
+        let state = self.state.clone();
+
+        // --- Service Swap Pattern ---
+        //
+        // Tower requires that poll_ready() is called before call(). After
+        // poll_ready succeeds, the service has reserved capacity for one
+        // request. We need to move this "readied" service into the async
+        // future, but we also need self.inner to be valid for future calls.
+        //
+        // Solution: clone self.inner (creating a fresh, un-readied copy),
+        // then swap so the readied service goes into the future and the
+        // fresh clone stays in self.inner. The caller will call poll_ready
+        // again before the next call, readying the fresh clone.
+        let mut inner = self.inner.clone();
+        std::mem::swap(&mut self.inner, &mut inner);
+        // Now: `inner` = readied service (for this request)
+        //      `self.inner` = fresh clone (for future requests)
+
+        Box::pin(async move {
+            // Briefly acquire a read lock to determine the auth method.
+            // We release it immediately to avoid holding the lock during
+            // potentially slow network I/O.
+            let method_kind = {
+                let guard = state.read().await;
+                guard.method.kind()
+            };
+
+            debug!(auth_method = ?method_kind, "authenticating request");
+
+            match method_kind {
+                AuthMethodKind::UserAccount | AuthMethodKind::ServiceAccount => {
+                    handle_bearer_auth(state, inner, req).await
+                }
+                AuthMethodKind::ApiKeys => handle_digest_auth(state, inner, req).await,
+            }
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Bearer Auth Flow
+// ---------------------------------------------------------------------------
+
+/// Handle Bearer token authentication (UserAccount or ServiceAccount).
+///
+/// 1. Get the cached token (or refresh if expired/missing).
+/// 2. Attach `Authorization: Bearer <token>` and send the request.
+/// 3. If the server responds with 401, invalidate the cache, refresh
+///    the token, and retry the request once.
+///
+/// The retry-on-401 logic handles the case where the access token has
+/// expired server-side but we don't know its expiry (e.g., tokens
+/// loaded from the keychain without expiry metadata).
+async fn handle_bearer_auth<S, ReqBody, ResBody>(
+    state: Arc<RwLock<AuthState>>,
+    mut inner: S,
+    req: Request<ReqBody>,
+) -> Result<Response<ResBody>, AuthError<S::Error>>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>> + Clone + Send + 'static,
+    S::Future: Send,
+    S::Error: Send + fmt::Debug,
+    ReqBody: From<Bytes> + Clone + Send + 'static,
+    ResBody: Body + Send + 'static,
+    ResBody::Data: Send,
+    ResBody::Error: Send + fmt::Debug,
+{
+    let access_token = get_or_refresh_token::<S, ReqBody, ResBody>(&state, inner.clone()).await?;
+
+    debug!(
+        token_prefix = &access_token[..access_token.len().min(8)],
+        token_len = access_token.len(),
+        "attaching Bearer token"
+    );
+
+    // Save request parts for a potential retry (same pattern as digest auth).
+    let method = req.method().clone();
+    let uri = req.uri().clone();
+    let version = req.version();
+    let headers = req.headers().clone();
+    let body_clone = req.body().clone();
+
+    let mut req = req;
+    req.headers_mut()
+        .insert(AUTHORIZATION, make_bearer_header(&access_token)?);
+
+    let response = inner.call(req).await.map_err(AuthError::Inner)?;
+    debug!(status = %response.status(), "API response received");
+
+    if response.status() != http::StatusCode::UNAUTHORIZED {
+        return Ok(response);
+    }
+
+    // --- 401 Retry Flow ---
+    //
+    // The server rejected our token. This typically happens when the
+    // access token expired server-side but we didn't know its expiry
+    // (tokens loaded from the keychain have no expiry metadata).
+    // Invalidate the cache, refresh, and retry once.
+    info!("received 401, refreshing token and retrying");
+
+    {
+        let mut guard = state.write().await;
+        guard.method.invalidate_token();
+    }
+
+    let new_token = get_or_refresh_token::<S, ReqBody, ResBody>(&state, inner.clone()).await?;
+
+    debug!(
+        token_prefix = &new_token[..new_token.len().min(8)],
+        token_len = new_token.len(),
+        "retrying with refreshed token"
+    );
+
+    // Rebuild the request with the new token.
+    let mut retry_req = Request::new(body_clone);
+    *retry_req.method_mut() = method;
+    *retry_req.uri_mut() = uri;
+    *retry_req.version_mut() = version;
+    *retry_req.headers_mut() = headers;
+    retry_req
+        .headers_mut()
+        .insert(AUTHORIZATION, make_bearer_header(&new_token)?);
+
+    std::future::poll_fn(|cx| inner.poll_ready(cx))
+        .await
+        .map_err(AuthError::Inner)?;
+
+    let response = inner.call(retry_req).await.map_err(AuthError::Inner)?;
+    debug!(status = %response.status(), "retry response received");
+    Ok(response)
+}
+
+fn make_bearer_header<E>(token: &str) -> Result<HeaderValue, AuthError<E>> {
+    HeaderValue::from_str(&format!("Bearer {token}")).map_err(|e| {
+        AuthError::TokenAcquisitionFailed(format!("token contains invalid header characters: {e}"))
+    })
+}
+
+/// Ensure we have a valid access token, refreshing if necessary.
+///
+/// This implements **double-checked locking** to minimize lock contention:
+///
+/// 1. **Read lock** (fast path): Check if the cached token is valid.
+///    Multiple concurrent requests can do this in parallel.
+/// 2. **Build token request** (read lock): Clone the credentials needed
+///    for the refresh call, then release the lock.
+/// 3. **HTTP call** (no lock): Ready the inner service clone and POST
+///    to the token endpoint. This is the slow part, and we do it
+///    without holding any lock so other requests can still read the cache.
+/// 4. **Write lock** (slow path): Double-check the cache (another task
+///    might have refreshed while we waited), update the cached token,
+///    and persist to the secret store.
+///
+/// The double-check in step 4 prevents redundant refreshes: if two tasks
+/// both see an expired token and both attempt to refresh, the second one
+/// to acquire the write lock will find a fresh token and skip the update.
+///
+/// Takes an owned clone of the inner service (rather than a reference)
+/// to avoid requiring `S: Sync`. The clone is only used if a token
+/// refresh is actually needed.
+async fn get_or_refresh_token<S, ReqBody, ResBody>(
+    state: &Arc<RwLock<AuthState>>,
+    mut inner: S,
+) -> Result<String, AuthError<S::Error>>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>> + Clone + Send + 'static,
+    S::Future: Send,
+    S::Error: Send + fmt::Debug,
+    ReqBody: From<Bytes> + Send + 'static,
+    ResBody: Body + Send + 'static,
+    ResBody::Data: Send,
+    ResBody::Error: Send + fmt::Debug,
+{
+    // Step 1: Fast path — check the cached token under a read lock.
+    {
+        let guard = state.read().await;
+        if let Some(token) = guard.method.cached_token() {
+            if !token.is_expired() {
+                debug!(
+                    expires_at = ?token.expires_at,
+                    "using cached token (not expired)"
+                );
+                return Ok(token.access_token.clone());
+            }
+            debug!(expires_at = ?token.expires_at, "cached token is expired");
+        } else {
+            debug!("no cached token available");
+        }
+    } // Read lock released.
+
+    // Step 2: Build the token request params (clone credentials while under read lock).
+    let (endpoint, form_body) = {
+        let guard = state.read().await;
+        guard.method.build_token_request().ok_or_else(|| {
+            AuthError::TokenAcquisitionFailed(
+                "auth method does not support token acquisition".to_string(),
+            )
+        })?
+    }; // Read lock released.
+
+    info!(endpoint = %endpoint, form_body_len = form_body.len(), "refreshing OAuth token");
+    debug!(form_body = %form_body, "token request body");
+
+    // Step 3: Ready the inner service clone and call the token endpoint.
+    std::future::poll_fn(|cx| inner.poll_ready(cx))
+        .await
+        .map_err(AuthError::Inner)?;
+
+    let response = oauth::acquire_token(&mut inner, &endpoint, form_body)
+        .await
+        .map_err(|e| {
+            warn!(error = %e, "token acquisition failed");
+            AuthError::TokenAcquisitionFailed(e.to_string())
+        })?;
+
+    info!("token refresh successful");
+
+    // Step 4: Write lock — update the cache and persist.
+    let mut guard = state.write().await;
+
+    // Double-check: another task might have refreshed while we were
+    // making the HTTP call. If so, use their (newer) token.
+    if let Some(token) = guard.method.cached_token()
+        && !token.is_expired()
+    {
+        debug!("another task already refreshed the token");
+        return Ok(token.access_token.clone());
+    }
+
+    let cached_token = CachedToken::from_response(&response);
+    let access_token = cached_token.access_token.clone();
+    debug!(
+        expires_at = ?cached_token.expires_at,
+        has_new_refresh_token = response.refresh_token.is_some(),
+        "caching new token"
+    );
+    guard.method.update_token(cached_token, &response)?;
+
+    Ok(access_token)
+}
+
+// ---------------------------------------------------------------------------
+// Digest Auth Flow
+// ---------------------------------------------------------------------------
+
+/// Handle HTTP Digest authentication (ApiKeys).
+///
+/// 1. Extract credentials from state.
+/// 2. Save the request parts (we'll need them to rebuild the request).
+/// 3. Send a "probe" request without authentication.
+/// 4. If 401 + Digest challenge:
+///    a. Parse the challenge (nonce, realm, algorithm, etc.).
+///    b. Compute the digest response hash.
+///    c. Rebuild the request with the `Authorization: Digest ...` header.
+///    d. Re-ready the inner service and send the retry.
+/// 5. If not 401, return the response as-is.
+async fn handle_digest_auth<S, ReqBody, ResBody>(
+    state: Arc<RwLock<AuthState>>,
+    mut inner: S,
+    req: Request<ReqBody>,
+) -> Result<Response<ResBody>, AuthError<S::Error>>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>> + Send + 'static,
+    S::Future: Send,
+    S::Error: Send,
+    ReqBody: Clone + Send + 'static,
+    ResBody: Body + Send + 'static,
+{
+    // Extract credentials (read lock, released immediately).
+    let (username, password) = {
+        let guard = state.read().await;
+        match &guard.method {
+            AuthMethod::ApiKeys {
+                public_key,
+                private_key,
+            } => (public_key.clone(), private_key.clone()),
+            _ => {
+                return Err(AuthError::DigestAuthFailed(
+                    "expected ApiKeys auth method".to_string(),
+                ));
+            }
+        }
+    };
+
+    // Save request parts for the retry. We can't clone Request<ReqBody>
+    // directly (http::Request doesn't implement Clone), so we save the
+    // individual components before the probe request consumes `req`.
+    let method = req.method().clone();
+    let uri = req.uri().clone();
+    let version = req.version();
+    let headers = req.headers().clone();
+    let body_clone = req.body().clone();
+
+    // The URI path is used in the digest hash computation.
+    // path_and_query() includes the query string, which is important
+    // for generating the correct digest response.
+    let uri_path = uri
+        .path_and_query()
+        .map(|pq| pq.as_str().to_string())
+        .unwrap_or_else(|| "/".to_string());
+
+    // --- Probe Request ---
+    // Send the original request without authentication. The server will
+    // respond with 401 + WWW-Authenticate if auth is required.
+    debug!(uri = %uri, method = %method, "sending digest probe request");
+    let probe_response = inner.call(req).await.map_err(AuthError::Inner)?;
+    debug!(status = %probe_response.status(), "probe response received");
+
+    // Check for a Digest challenge in the response.
+    let Some(mut challenge) = digest::extract_digest_challenge(&probe_response)? else {
+        debug!("no digest challenge in response, passing through");
+        // Not a 401 or not a Digest challenge. The endpoint might not
+        // require auth, or it uses a different auth scheme.
+        return Ok(probe_response);
+    };
+
+    debug!("digest challenge received, computing response");
+
+    // --- Compute Digest ---
+    let auth_header = digest::compute_authorization_header(
+        &mut challenge,
+        &username,
+        &password,
+        method.as_str(),
+        &uri_path,
+    )?;
+
+    // --- Rebuild Request ---
+    // Construct a new request with the original method/uri/headers/body
+    // plus the computed Authorization header.
+    let mut retry_req = Request::new(body_clone);
+    *retry_req.method_mut() = method;
+    *retry_req.uri_mut() = uri;
+    *retry_req.version_mut() = version;
+    *retry_req.headers_mut() = headers;
+    retry_req.headers_mut().insert(AUTHORIZATION, auth_header);
+
+    // --- Retry ---
+    // The inner service was already used for the probe request. Tower
+    // services may need poll_ready() again between calls, so we re-ready
+    // the service before the retry.
+    std::future::poll_fn(|cx| inner.poll_ready(cx))
+        .await
+        .map_err(AuthError::Inner)?;
+
+    inner.call(retry_req).await.map_err(AuthError::Inner)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use http::StatusCode;
+    use http::header::WWW_AUTHENTICATE;
+    use http_body_util::Full;
+    use std::collections::VecDeque;
+    use std::convert::Infallible;
+    use std::sync::Mutex;
+    use tower::ServiceExt as _;
+
+    use crate::secrets::{MockSecretStore, Secret};
+
+    // -- Mock HTTP Service --
+
+    /// Records made by the mock HTTP service for later assertion.
+    #[derive(Debug)]
+    #[allow(dead_code)]
+    struct CapturedRequest {
+        method: http::Method,
+        uri: http::Uri,
+        headers: http::HeaderMap,
+    }
+
+    /// A mock Tower service that returns pre-configured responses
+    /// and captures incoming requests for test assertions.
+    ///
+    /// We use a custom mock because it's simpler for our use case:
+    /// we just need a queue of responses and a record of requests.
+    #[derive(Clone)]
+    struct MockHttpService {
+        responses: Arc<Mutex<VecDeque<Response<Full<Bytes>>>>>,
+        captured_requests: Arc<Mutex<Vec<CapturedRequest>>>,
+    }
+
+    impl MockHttpService {
+        fn new(responses: Vec<Response<Full<Bytes>>>) -> Self {
+            MockHttpService {
+                responses: Arc::new(Mutex::new(VecDeque::from(responses))),
+                captured_requests: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        /// Drain and return all captured requests.
+        fn take_captured_requests(&self) -> Vec<CapturedRequest> {
+            self.captured_requests.lock().unwrap().drain(..).collect()
+        }
+    }
+
+    impl Service<Request<Full<Bytes>>> for MockHttpService {
+        type Response = Response<Full<Bytes>>;
+        type Error = Infallible;
+        type Future =
+            Pin<Box<dyn Future<Output = Result<Response<Full<Bytes>>, Infallible>> + Send>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, req: Request<Full<Bytes>>) -> Self::Future {
+            self.captured_requests
+                .lock()
+                .unwrap()
+                .push(CapturedRequest {
+                    method: req.method().clone(),
+                    uri: req.uri().clone(),
+                    headers: req.headers().clone(),
+                });
+
+            let response = self
+                .responses
+                .lock()
+                .unwrap()
+                .pop_front()
+                .expect("MockHttpService: ran out of configured responses");
+
+            Box::pin(async move { Ok(response) })
+        }
+    }
+
+    // -- Test Helpers --
+
+    fn ok_response() -> Response<Full<Bytes>> {
+        Response::builder()
+            .status(StatusCode::OK)
+            .body(Full::new(Bytes::new()))
+            .unwrap()
+    }
+
+    /// Build a mock token endpoint response with JSON body.
+    fn token_endpoint_response(
+        access_token: &str,
+        refresh_token: Option<&str>,
+        expires_in: Option<u64>,
+    ) -> Response<Full<Bytes>> {
+        let mut json = serde_json::json!({ "access_token": access_token });
+        if let Some(rt) = refresh_token {
+            json["refresh_token"] = serde_json::json!(rt);
+        }
+        if let Some(ei) = expires_in {
+            json["expires_in"] = serde_json::json!(ei);
+        }
+        Response::builder()
+            .status(StatusCode::OK)
+            .header("Content-Type", "application/json")
+            .body(Full::new(Bytes::from(serde_json::to_vec(&json).unwrap())))
+            .unwrap()
+    }
+
+    fn digest_challenge_response() -> Response<Full<Bytes>> {
+        Response::builder()
+            .status(StatusCode::UNAUTHORIZED)
+            .header(
+                WWW_AUTHENTICATE,
+                r#"Digest realm="test@example.org", qop="auth", algorithm=MD5, nonce="test-nonce-123", opaque="test-opaque""#,
+            )
+            .body(Full::new(Bytes::new()))
+            .unwrap()
+    }
+
+    fn get_request(uri: &str) -> Request<Full<Bytes>> {
+        Request::builder()
+            .method(http::Method::GET)
+            .uri(uri)
+            .body(Full::new(Bytes::new()))
+            .unwrap()
+    }
+
+    // -- Bearer Auth Tests --
+
+    #[tokio::test]
+    async fn bearer_with_valid_cached_token_skips_refresh() {
+        let layer = AuthenticationLayer {
+            state: Arc::new(RwLock::new(AuthState {
+                method: AuthMethod::UserAccount {
+                    cached_token: Some(CachedToken::new("cached-access-token".into())),
+                    refresh_token: "test-refresh-token".into(),
+                    token_endpoint: "https://example.com/token".into(),
+                    client_id: "test-client-id".into(),
+                    secret_store: Box::new(MockSecretStore::new()),
+                    profile_name: "default".into(),
+                },
+            })),
+        };
+
+        // Only one response needed — no token refresh, just the API call.
+        let mock_svc = MockHttpService::new(vec![ok_response()]);
+        let mut svc = layer.layer(mock_svc.clone());
+
+        let response = svc
+            .ready()
+            .await
+            .unwrap()
+            .call(get_request("http://api.example.com/test"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let captured = mock_svc.take_captured_requests();
+        assert_eq!(
+            captured.len(),
+            1,
+            "expected only the API request, no token refresh"
+        );
+        assert_eq!(
+            captured[0].headers.get(AUTHORIZATION).unwrap(),
+            "Bearer cached-access-token"
+        );
+    }
+
+    #[tokio::test]
+    async fn bearer_refreshes_expired_token_and_persists() {
+        let expired_token = CachedToken {
+            access_token: "old-token".into(),
+            expires_at: Some(std::time::Instant::now() - std::time::Duration::from_secs(60)),
+        };
+
+        let mut mock_store = MockSecretStore::new();
+        mock_store
+            .expect_set()
+            .withf(|profile, secret| {
+                profile == "default"
+                    && match secret {
+                        Secret::UserAccount(ua) => {
+                            ua.access_token == "new-access-token"
+                                && ua.refresh_token == "new-refresh-token"
+                        }
+                        _ => false,
+                    }
+            })
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        let layer = AuthenticationLayer {
+            state: Arc::new(RwLock::new(AuthState {
+                method: AuthMethod::UserAccount {
+                    cached_token: Some(expired_token),
+                    refresh_token: "old-refresh-token".into(),
+                    token_endpoint: "https://example.com/token".into(),
+                    client_id: "test-client-id".into(),
+                    secret_store: Box::new(mock_store),
+                    profile_name: "default".into(),
+                },
+            })),
+        };
+
+        // Two responses: first for token refresh, then for the API call.
+        let mock_svc = MockHttpService::new(vec![
+            token_endpoint_response("new-access-token", Some("new-refresh-token"), Some(3600)),
+            ok_response(),
+        ]);
+        let mut svc = layer.layer(mock_svc.clone());
+
+        let response = svc
+            .ready()
+            .await
+            .unwrap()
+            .call(get_request("http://api.example.com/test"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let captured = mock_svc.take_captured_requests();
+        assert_eq!(captured.len(), 2, "expected token refresh + API request");
+
+        // First request: POST to token endpoint.
+        assert_eq!(captured[0].method, http::Method::POST);
+        assert_eq!(captured[0].uri, "https://example.com/token");
+
+        // Second request: GET to API with the new Bearer token.
+        assert_eq!(
+            captured[1].headers.get(AUTHORIZATION).unwrap(),
+            "Bearer new-access-token"
+        );
+    }
+
+    #[tokio::test]
+    async fn bearer_acquires_token_when_none_cached() {
+        let mut mock_store = MockSecretStore::new();
+        mock_store.expect_set().times(1).returning(|_, _| Ok(()));
+
+        let layer = AuthenticationLayer {
+            state: Arc::new(RwLock::new(AuthState {
+                method: AuthMethod::UserAccount {
+                    cached_token: None,
+                    refresh_token: "my-refresh-token".into(),
+                    token_endpoint: "https://example.com/token".into(),
+                    client_id: "test-client-id".into(),
+                    secret_store: Box::new(mock_store),
+                    profile_name: "default".into(),
+                },
+            })),
+        };
+
+        // Two responses: token refresh + API call.
+        let mock_svc = MockHttpService::new(vec![
+            token_endpoint_response("fresh-token", None, Some(3600)),
+            ok_response(),
+        ]);
+        let mut svc = layer.layer(mock_svc.clone());
+
+        let response = svc
+            .ready()
+            .await
+            .unwrap()
+            .call(get_request("http://api.example.com/test"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let captured = mock_svc.take_captured_requests();
+        assert_eq!(captured.len(), 2);
+        assert_eq!(
+            captured[1].headers.get(AUTHORIZATION).unwrap(),
+            "Bearer fresh-token"
+        );
+    }
+
+    // -- Client Credentials Tests --
+
+    #[tokio::test]
+    async fn client_credentials_acquires_token_when_none_cached() {
+        let layer = AuthenticationLayer {
+            state: Arc::new(RwLock::new(AuthState {
+                method: AuthMethod::ServiceAccount {
+                    cached_token: None,
+                    client_id: "my-client-id".into(),
+                    client_secret: "my-client-secret".into(),
+                    token_endpoint: "https://example.com/token".into(),
+                },
+            })),
+        };
+
+        // Two responses: token acquisition + API call.
+        let mock_svc = MockHttpService::new(vec![
+            token_endpoint_response("service-token", None, Some(3600)),
+            ok_response(),
+        ]);
+        let mut svc = layer.layer(mock_svc.clone());
+
+        let response = svc
+            .ready()
+            .await
+            .unwrap()
+            .call(get_request("http://api.example.com/test"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let captured = mock_svc.take_captured_requests();
+        assert_eq!(captured.len(), 2);
+
+        // First request: POST to token endpoint with client credentials.
+        assert_eq!(captured[0].method, http::Method::POST);
+        assert_eq!(captured[0].uri, "https://example.com/token");
+
+        // Second request: GET to API with the acquired Bearer token.
+        assert_eq!(
+            captured[1].headers.get(AUTHORIZATION).unwrap(),
+            "Bearer service-token"
+        );
+    }
+
+    #[tokio::test]
+    async fn client_credentials_reuses_valid_cached_token() {
+        let layer = AuthenticationLayer {
+            state: Arc::new(RwLock::new(AuthState {
+                method: AuthMethod::ServiceAccount {
+                    cached_token: Some(CachedToken::new("cached-service-token".into())),
+                    client_id: "my-client-id".into(),
+                    client_secret: "my-client-secret".into(),
+                    token_endpoint: "https://example.com/token".into(),
+                },
+            })),
+        };
+
+        // Only one response — no token refresh needed.
+        let mock_svc = MockHttpService::new(vec![ok_response()]);
+        let mut svc = layer.layer(mock_svc.clone());
+
+        let response = svc
+            .ready()
+            .await
+            .unwrap()
+            .call(get_request("http://api.example.com/test"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let captured = mock_svc.take_captured_requests();
+        assert_eq!(captured.len(), 1, "expected only the API request");
+        assert_eq!(
+            captured[0].headers.get(AUTHORIZATION).unwrap(),
+            "Bearer cached-service-token"
+        );
+    }
+
+    // -- Digest Auth Tests --
+
+    #[tokio::test]
+    async fn digest_handles_challenge_response_flow() {
+        let layer = AuthenticationLayer::api_keys("my-public-key".into(), "my-private-key".into());
+
+        // First response: 401 with digest challenge
+        // Second response: 200 OK (after successful digest auth)
+        let mock_svc = MockHttpService::new(vec![digest_challenge_response(), ok_response()]);
+        let mut svc = layer.layer(mock_svc.clone());
+
+        let response = svc
+            .ready()
+            .await
+            .unwrap()
+            .call(get_request("http://api.example.com/api/atlas/v2/groups"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let captured = mock_svc.take_captured_requests();
+        assert_eq!(captured.len(), 2, "expected probe + retry");
+
+        // Probe request should have no Authorization header.
+        assert!(
+            captured[0].headers.get(AUTHORIZATION).is_none(),
+            "probe should not have Authorization header"
+        );
+
+        // Retry request should have a Digest Authorization header.
+        let auth_header = captured[1]
+            .headers
+            .get(AUTHORIZATION)
+            .expect("retry should have Authorization header");
+        let auth_str = auth_header.to_str().unwrap();
+        assert!(
+            auth_str.starts_with("Digest "),
+            "expected Digest auth, got: {auth_str}"
+        );
+        assert!(
+            auth_str.contains("username=\"my-public-key\""),
+            "expected username in digest header, got: {auth_str}"
+        );
+    }
+
+    #[tokio::test]
+    async fn digest_passes_through_non_401_response() {
+        let layer = AuthenticationLayer::api_keys("my-public-key".into(), "my-private-key".into());
+
+        let mock_svc = MockHttpService::new(vec![ok_response()]);
+        let mut svc = layer.layer(mock_svc.clone());
+
+        let response = svc
+            .ready()
+            .await
+            .unwrap()
+            .call(get_request("http://api.example.com/test"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let captured = mock_svc.take_captured_requests();
+        assert_eq!(captured.len(), 1, "should not retry for non-401");
+    }
+
+    #[tokio::test]
+    async fn digest_passes_through_401_without_digest_scheme() {
+        // Server returns 401 but with Basic auth, not Digest.
+        let basic_401 = Response::builder()
+            .status(StatusCode::UNAUTHORIZED)
+            .header(WWW_AUTHENTICATE, "Basic realm=\"test\"")
+            .body(Full::new(Bytes::new()))
+            .unwrap();
+
+        let layer = AuthenticationLayer::api_keys("my-public-key".into(), "my-private-key".into());
+
+        let mock_svc = MockHttpService::new(vec![basic_401]);
+        let mut svc = layer.layer(mock_svc.clone());
+
+        let response = svc
+            .ready()
+            .await
+            .unwrap()
+            .call(get_request("http://api.example.com/test"))
+            .await
+            .unwrap();
+
+        // Should pass through the 401 since it's not a Digest challenge.
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+        let captured = mock_svc.take_captured_requests();
+        assert_eq!(captured.len(), 1, "should not retry for non-Digest 401");
+    }
+
+    // -- Error Handling Tests --
+
+    #[tokio::test]
+    async fn token_acquisition_failure_returns_error() {
+        let mut mock_store = MockSecretStore::new();
+        // set() should never be called since acquisition fails.
+        mock_store.expect_set().never();
+
+        let layer = AuthenticationLayer {
+            state: Arc::new(RwLock::new(AuthState {
+                method: AuthMethod::UserAccount {
+                    cached_token: None,
+                    refresh_token: "my-refresh-token".into(),
+                    token_endpoint: "https://example.com/token".into(),
+                    client_id: "test-client-id".into(),
+                    secret_store: Box::new(mock_store),
+                    profile_name: "default".into(),
+                },
+            })),
+        };
+
+        // Return a 400 error from the token endpoint.
+        let error_response = Response::builder()
+            .status(StatusCode::BAD_REQUEST)
+            .body(Full::new(Bytes::from(r#"{"error":"invalid_grant"}"#)))
+            .unwrap();
+
+        let mock_svc = MockHttpService::new(vec![error_response]);
+        let mut svc = layer.layer(mock_svc);
+
+        let result = svc
+            .ready()
+            .await
+            .unwrap()
+            .call(get_request("http://api.example.com/test"))
+            .await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(&err, AuthError::TokenAcquisitionFailed(msg) if msg.contains("400")),
+            "expected TokenAcquisitionFailed with status 400, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn digest_malformed_challenge_returns_error() {
+        let malformed_response = Response::builder()
+            .status(StatusCode::UNAUTHORIZED)
+            .header(WWW_AUTHENTICATE, "Digest this-is-not-valid")
+            .body(Full::new(Bytes::new()))
+            .unwrap();
+
+        let layer = AuthenticationLayer::api_keys("my-public-key".into(), "my-private-key".into());
+
+        let mock_svc = MockHttpService::new(vec![malformed_response]);
+        let mut svc = layer.layer(mock_svc);
+
+        let result = svc
+            .ready()
+            .await
+            .unwrap()
+            .call(get_request("http://api.example.com/test"))
+            .await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(&err, AuthError::DigestAuthFailed(_)),
+            "expected DigestAuthFailed, got: {err:?}"
+        );
+    }
+
+    // -- from_config Tests --
+
+    #[tokio::test]
+    async fn from_config_creates_user_account_layer() {
+        use crate::config::{AtlasCLIConfig, AuthType};
+
+        let mut mock_store = MockSecretStore::new();
+        mock_store
+            .expect_get()
+            .withf(|profile, auth_type| profile == "default" && *auth_type == AuthType::UserAccount)
+            .times(1)
+            .returning(|_, _| {
+                Ok(Some(Secret::UserAccount(UserAccount::new(
+                    "my-access-token".into(),
+                    "my-refresh-token".into(),
+                ))))
+            });
+
+        let config = AtlasCLIConfig {
+            auth_type: Some(AuthType::UserAccount),
+            ..Default::default()
+        };
+
+        let layer = AuthenticationLayer::from_config(&config, "default", Box::new(mock_store))
+            .expect("from_config should succeed");
+
+        // Verify the layer produces a working service with a cached token.
+        let mock_svc = MockHttpService::new(vec![ok_response()]);
+        let mut svc = layer.layer(mock_svc.clone());
+
+        let response = svc
+            .ready()
+            .await
+            .unwrap()
+            .call(get_request("http://api.example.com/test"))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let captured = mock_svc.take_captured_requests();
+        assert_eq!(captured.len(), 1);
+        assert_eq!(
+            captured[0].headers.get(AUTHORIZATION).unwrap(),
+            "Bearer my-access-token"
+        );
+    }
+}

--- a/src/client/digest.rs
+++ b/src/client/digest.rs
@@ -1,0 +1,244 @@
+//! HTTP Digest authentication helpers.
+//!
+//! This module provides functions for the HTTP Digest authentication
+//! challenge-response flow, using the [`digest_auth`] crate for the
+//! cryptographic heavy lifting.
+//!
+//! # How HTTP Digest Auth Works
+//!
+//! Unlike Basic auth (which sends credentials in plaintext), Digest auth
+//! uses a challenge-response protocol that never sends the password over
+//! the wire:
+//!
+//! ```text
+//! Client                              Server
+//!   |                                    |
+//!   |--- GET /resource (no auth) ------->|
+//!   |                                    |
+//!   |<-- 401 + WWW-Authenticate: --------|
+//!   |    Digest realm="...",             |
+//!   |    nonce="...", qop="auth"         |
+//!   |                                    |
+//!   |--- GET /resource + Authorization: -|
+//!   |    Digest username="...",          |
+//!   |    response="<hash>", ...          |
+//!   |                                    |
+//!   |<-- 200 OK -------------------------|
+//! ```
+//!
+//! The response hash is computed as:
+//! ```text
+//! HA1 = H(username:realm:password)
+//! HA2 = H(method:uri)
+//! response = H(HA1:nonce:nc:cnonce:qop:HA2)
+//! ```
+//!
+//! Where `H` is typically MD5 (RFC 2617) or SHA-256 (RFC 7616). The
+//! [`digest_auth`] crate supports both and negotiates based on the
+//! server's `algorithm` parameter.
+
+use std::borrow::Cow;
+
+use digest_auth::{AuthContext, HttpMethod, WwwAuthenticateHeader};
+use http::header::WWW_AUTHENTICATE;
+use http::{HeaderValue, Response, StatusCode};
+
+use super::error::AuthError;
+
+/// Extract a Digest authentication challenge from an HTTP response.
+///
+/// Checks if the response is a `401 Unauthorized` with a
+/// `WWW-Authenticate: Digest ...` header. If so, parses the challenge
+/// and returns the parsed [`WwwAuthenticateHeader`].
+///
+/// Returns `Ok(None)` if:
+/// - The response status is not 401
+/// - There's no `WWW-Authenticate` header
+/// - The `WWW-Authenticate` header uses a different scheme (e.g., Basic)
+///
+/// Returns `Err(AuthError::DigestAuthFailed)` if the header is present
+/// and starts with "Digest" but can't be parsed.
+pub fn extract_digest_challenge<B, E>(
+    response: &Response<B>,
+) -> Result<Option<WwwAuthenticateHeader>, AuthError<E>> {
+    if response.status() != StatusCode::UNAUTHORIZED {
+        return Ok(None);
+    }
+
+    let Some(www_auth) = response.headers().get(WWW_AUTHENTICATE) else {
+        return Ok(None);
+    };
+
+    // The header value must be valid ASCII for digest auth
+    let www_auth_str = www_auth.to_str().map_err(|e| {
+        AuthError::DigestAuthFailed(format!("non-ASCII WWW-Authenticate header: {e}"))
+    })?;
+
+    // Only handle Digest challenges — ignore Basic, Bearer, etc.
+    if !www_auth_str.starts_with("Digest ") {
+        return Ok(None);
+    }
+
+    // Parse the challenge header into its components (realm, nonce, qop,
+    // algorithm, opaque, etc.). The digest_auth crate handles all the
+    // parsing complexity defined in RFC 2617 and 7616.
+    let challenge = digest_auth::parse(www_auth_str).map_err(|e| {
+        AuthError::DigestAuthFailed(format!("failed to parse digest challenge: {e}"))
+    })?;
+
+    Ok(Some(challenge))
+}
+
+/// Compute an `Authorization: Digest ...` header value from a challenge.
+///
+/// Takes a parsed digest challenge (from [`extract_digest_challenge`]),
+/// the user's credentials, and the request details (method, URI), and
+/// computes the appropriate digest response hash.
+///
+/// The [`digest_auth`] crate handles all the cryptographic details:
+/// - Generating a random `cnonce` (client nonce) for replay protection
+/// - Computing the response hash using MD5 or SHA-256 (server-negotiated)
+/// - Formatting the complete `Authorization: Digest ...` header value
+/// - Tracking the nonce count (`nc`) for nonce reuse
+///
+/// # Arguments
+///
+/// * `challenge` - Mutable because the `digest_auth` crate tracks the nonce
+///   count (`nc`) internally, incrementing it on each call to `respond()`.
+/// * `username` - The public API key (used as the digest username).
+/// * `password` - The private API key (used as the digest password).
+/// * `method` - The HTTP method string (e.g., "GET", "POST").
+/// * `uri` - The request URI path (e.g., "/api/atlas/v2/groups").
+pub fn compute_authorization_header<E>(
+    challenge: &mut WwwAuthenticateHeader,
+    username: &str,
+    password: &str,
+    method: &str,
+    uri: &str,
+) -> Result<HeaderValue, AuthError<E>> {
+    // The digest_auth crate uses Cow<str> for its string fields,
+    // allowing both borrowed and owned strings. We use Cow::Borrowed
+    // since we already have string slices.
+    let context = AuthContext {
+        username: Cow::Borrowed(username),
+        password: Cow::Borrowed(password),
+        uri: Cow::Borrowed(uri),
+        // The body is only needed for qop=auth-int (integrity protection).
+        // MongoDB Atlas uses qop=auth, which only protects the URI.
+        body: None,
+        method: HttpMethod(Cow::Owned(method.to_string())),
+        // When cnonce is None, digest_auth generates a cryptographically
+        // random one automatically. Only set this for testing.
+        cnonce: None,
+    };
+
+    // Compute the digest response. This performs:
+    //   HA1 = H(username:realm:password)
+    //   HA2 = H(method:uri)
+    //   response = H(HA1:nonce:nc:cnonce:qop:HA2)
+    // where H is MD5 or SHA-256 depending on the server's algorithm parameter.
+    let answer = challenge.respond(&context).map_err(|e| {
+        AuthError::DigestAuthFailed(format!("failed to compute digest response: {e}"))
+    })?;
+
+    // The to_string() output is the complete header value:
+    //   Digest username="...", realm="...", nonce="...", uri="...", response="...", ...
+    HeaderValue::from_str(&answer.to_string()).map_err(|e| {
+        AuthError::DigestAuthFailed(format!("digest header contains invalid characters: {e}"))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use http_body_util::Full;
+
+    #[test]
+    fn extract_challenge_from_401_with_digest() {
+        let response = Response::builder()
+            .status(StatusCode::UNAUTHORIZED)
+            .header(
+                WWW_AUTHENTICATE,
+                r#"Digest realm="test@example.org", qop="auth", algorithm=MD5, nonce="abc123", opaque="xyz""#,
+            )
+            .body(Full::<Bytes>::new(Bytes::new()))
+            .unwrap();
+
+        let challenge: Result<Option<WwwAuthenticateHeader>, AuthError<String>> =
+            extract_digest_challenge(&response);
+
+        assert!(challenge.is_ok());
+        let challenge = challenge.unwrap();
+        assert!(challenge.is_some());
+
+        let challenge = challenge.unwrap();
+        assert_eq!(challenge.realm, "test@example.org");
+        assert_eq!(challenge.nonce, "abc123");
+    }
+
+    #[test]
+    fn extract_challenge_returns_none_for_200() {
+        let response = Response::builder()
+            .status(StatusCode::OK)
+            .body(Full::<Bytes>::new(Bytes::new()))
+            .unwrap();
+
+        let challenge: Result<Option<WwwAuthenticateHeader>, AuthError<String>> =
+            extract_digest_challenge(&response);
+
+        assert!(challenge.unwrap().is_none());
+    }
+
+    #[test]
+    fn extract_challenge_returns_none_for_basic_auth() {
+        let response = Response::builder()
+            .status(StatusCode::UNAUTHORIZED)
+            .header(WWW_AUTHENTICATE, "Basic realm=\"test\"")
+            .body(Full::<Bytes>::new(Bytes::new()))
+            .unwrap();
+
+        let challenge: Result<Option<WwwAuthenticateHeader>, AuthError<String>> =
+            extract_digest_challenge(&response);
+
+        assert!(challenge.unwrap().is_none());
+    }
+
+    #[test]
+    fn extract_challenge_returns_none_for_401_without_header() {
+        let response = Response::builder()
+            .status(StatusCode::UNAUTHORIZED)
+            .body(Full::<Bytes>::new(Bytes::new()))
+            .unwrap();
+
+        let challenge: Result<Option<WwwAuthenticateHeader>, AuthError<String>> =
+            extract_digest_challenge(&response);
+
+        assert!(challenge.unwrap().is_none());
+    }
+
+    #[test]
+    fn compute_digest_header_produces_valid_output() {
+        let www_auth = r#"Digest realm="test@example.org", qop="auth", algorithm=MD5, nonce="test-nonce", opaque="test-opaque""#;
+        let mut challenge = digest_auth::parse(www_auth).unwrap();
+
+        let header: Result<HeaderValue, AuthError<String>> = compute_authorization_header(
+            &mut challenge,
+            "my-username",
+            "my-password",
+            "GET",
+            "/api/v2/test",
+        );
+
+        assert!(header.is_ok());
+        let header = header.unwrap();
+        let header_str = header.to_str().unwrap();
+
+        assert!(header_str.starts_with("Digest "));
+        assert!(header_str.contains("username=\"my-username\""));
+        assert!(header_str.contains("realm=\"test@example.org\""));
+        assert!(header_str.contains("nonce=\"test-nonce\""));
+        assert!(header_str.contains("uri=\"/api/v2/test\""));
+        assert!(header_str.contains("response=\""));
+    }
+}

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -1,0 +1,134 @@
+//! Error types for the authentication middleware.
+//!
+//! The main error type [`AuthError`] is generic over `E`, which represents the
+//! inner service's error type. This follows the standard Tower pattern where
+//! middleware wraps the inner service's error type, allowing callers to handle
+//! errors from either the middleware or the underlying HTTP client.
+
+use std::fmt;
+
+use crate::secrets::SecretStoreError;
+
+/// Errors that can occur during the authentication process.
+///
+/// This enum is generic over `E` — the error type of the inner
+/// Tower [`Service`](tower::Service). This design preserves type information
+/// from the wrapped HTTP client while also surfacing middleware-specific errors.
+///
+/// # Why generic?
+///
+/// Tower services can have any error type (there are no trait bounds on
+/// `Service::Error`). By parameterizing `AuthError` over the inner error type,
+/// callers can pattern-match on both middleware errors and transport errors
+/// without losing type information or boxing.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// match error {
+///     AuthError::Inner(e) => {
+///         // Handle HTTP client errors (timeouts, connection refused, etc.)
+///     }
+///     AuthError::TokenAcquisitionFailed(msg) => {
+///         // Handle OAuth2 token refresh failures
+///     }
+///     _ => { /* ... */ }
+/// }
+/// ```
+#[derive(Debug)]
+pub enum AuthError<E> {
+    /// An error originating from the inner HTTP service.
+    ///
+    /// This variant wraps errors like connection failures, timeouts,
+    /// or any other transport-level errors from the underlying client.
+    Inner(E),
+
+    /// Failed to acquire or refresh an OAuth2 access token.
+    ///
+    /// This can happen when:
+    /// - The token endpoint is unreachable
+    /// - The refresh token is invalid or expired
+    /// - The client credentials are incorrect
+    /// - The token response is malformed
+    TokenAcquisitionFailed(String),
+
+    /// Failed to perform HTTP Digest authentication.
+    ///
+    /// This can happen when:
+    /// - The server's `WWW-Authenticate` header is malformed
+    /// - The digest algorithm is unsupported
+    /// - The authorization header couldn't be constructed
+    DigestAuthFailed(String),
+
+    /// Failed to persist a refreshed token to the secret store.
+    SecretStoreError(SecretStoreError),
+}
+
+// We implement Display manually instead of using thiserror because
+// thiserror's derive macro requires `E: Display` at the type level,
+// but Tower services don't guarantee Display on their error types.
+// By implementing manually, we only require E: Display where Display
+// is actually used (in the impl block), not on the struct definition.
+impl<E: fmt::Display> fmt::Display for AuthError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AuthError::Inner(e) => write!(f, "inner service error: {e}"),
+            AuthError::TokenAcquisitionFailed(msg) => {
+                write!(f, "token acquisition failed: {msg}")
+            }
+            AuthError::DigestAuthFailed(msg) => {
+                write!(f, "digest authentication failed: {msg}")
+            }
+            AuthError::SecretStoreError(e) => {
+                write!(f, "secret store error: {e}")
+            }
+        }
+    }
+}
+
+// std::error::Error requires Debug + Display. The `source()` method enables
+// error chaining: callers can traverse the error chain to find root causes.
+impl<E: fmt::Debug + fmt::Display> std::error::Error for AuthError<E> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            AuthError::SecretStoreError(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+/// Convenience conversion: allows using the `?` operator on `SecretStoreError`
+/// inside functions that return `Result<_, AuthError<E>>`.
+impl<E> From<SecretStoreError> for AuthError<E> {
+    fn from(e: SecretStoreError) -> Self {
+        AuthError::SecretStoreError(e)
+    }
+}
+
+/// Errors that can occur when constructing an [`AuthenticationLayer`](super::AuthenticationLayer)
+/// from an [`AtlasCLIConfig`](crate::config::AtlasCLIConfig).
+///
+/// These are *setup-time* errors (not per-request errors like [`AuthError`]).
+/// They indicate that the config or secret store doesn't contain enough
+/// information to construct the authentication layer.
+#[derive(Debug, thiserror::Error)]
+pub enum FromConfigError {
+    /// The config doesn't specify an `auth_type`.
+    #[error("auth_type is not set in the config")]
+    MissingAuthType,
+
+    /// No secret was found in the secret store for the configured profile
+    /// and auth type.
+    #[error("no credentials found in the secret store for this profile and auth type")]
+    SecretNotFound,
+
+    /// The secret stored in the secret store doesn't match the configured
+    /// `auth_type` (e.g., config says `UserAccount` but the secret store
+    /// contains `ApiKeys`).
+    #[error("secret type in store doesn't match the configured auth_type")]
+    AuthTypeMismatch,
+
+    /// An error from the secret store.
+    #[error("secret store error: {0}")]
+    SecretStoreError(#[from] SecretStoreError),
+}

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,0 +1,56 @@
+use tower_http::{
+    classify::StatusInRangeAsFailures, decompression::DecompressionLayer, set_header::SetRequestHeaderLayer, trace::TraceLayer
+};
+use tower::{ServiceBuilder, Service, ServiceExt};
+use hyper_util::{rt::TokioExecutor, client::legacy::Client, client::proxy::matcher};
+use http_body_util::{BodyExt, Full};
+use bytes::Bytes;
+use http::{HeaderValue, Request, Uri, header::USER_AGENT};
+
+pub async fn make_request() {
+    let proxy_matcher = matcher::Matcher::from_env();
+
+    let client = Client::builder(TokioExecutor::new()).build_http();
+        let mut client = ServiceBuilder::new()
+            // Add tracing and consider server errors and client
+            // errors as failures.
+            .layer(TraceLayer::new(
+                StatusInRangeAsFailures::new(400..=599).into_make_classifier()
+            ))
+            // Set a `User-Agent` header on all requests.
+            .layer(SetRequestHeaderLayer::overriding(
+                USER_AGENT,
+                HeaderValue::from_static("tower-http demo")
+            ))
+            // Decompress response bodies
+            .layer(DecompressionLayer::new())
+            // Wrap a `Client` in our middleware stack.
+            // This is possible because `Client` implements
+            // `tower::Service`.
+            .service(client);
+
+        let mut uri: Uri = "http://example.com".try_into().unwrap();
+        if let Some(intercept) = proxy_matcher.intercept(&uri) {
+            uri = intercept.uri().clone();
+        }
+    
+        // Make a request
+        let request = Request::builder()
+            .uri(uri)
+            .body(Full::<Bytes>::default())
+            .unwrap();
+    
+        let response = client
+            .ready()
+            .await
+            .unwrap()
+            .call(request)
+            .await
+            .unwrap();
+
+        let body = response.into_body();
+        let bytes = body.collect().await.unwrap().to_bytes().to_vec();
+        let body = String::from_utf8(bytes).unwrap();
+        println!("{}", body);
+
+    }

--- a/src/client/oauth.rs
+++ b/src/client/oauth.rs
@@ -1,0 +1,311 @@
+//! OAuth2 token types and token acquisition via the inner Tower service.
+//!
+//! This module provides the types used for OAuth2 token management
+//! in the authentication middleware:
+//!
+//! - [`CachedToken`]: An in-memory cached access token with expiry tracking.
+//! - [`OAuthTokenResponse`]: The parsed response from an OAuth2 token endpoint.
+//! - [`OAuthError`]: Errors during token acquisition.
+//! - [`acquire_token`]: Sends a token request through a Tower service.
+//!
+//! # Token Acquisition Architecture
+//!
+//! Instead of requiring callers to provide a token acquisition closure,
+//! the middleware acquires tokens by making HTTP POST requests through
+//! the **inner Tower service** that it already wraps. This means:
+//!
+//! 1. Token refresh uses the same transport as regular API requests
+//!    (same TLS config, proxy settings, connection pool).
+//! 2. The token request bypasses the authentication layer — you don't
+//!    need authentication to *obtain* authentication.
+//! 3. Users don't need to construct or wire up a separate HTTP client.
+
+use std::fmt;
+use std::time::{Duration, Instant};
+
+use bytes::{Buf, Bytes};
+use http::{Request, Response};
+use http_body::Body;
+use http_body_util::BodyExt;
+use tower::Service;
+use tracing::{debug, warn};
+
+/// The response from an OAuth2 token endpoint.
+///
+/// This struct represents the relevant fields from a JSON token response:
+/// ```json
+/// {
+///   "access_token": "eyJhbGciOiJ...",
+///   "refresh_token": "dGhpcyBpcyBh...",
+///   "expires_in": 3600
+/// }
+/// ```
+#[derive(Debug, Clone)]
+pub struct OAuthTokenResponse {
+    /// The access token issued by the authorization server.
+    pub access_token: String,
+
+    /// An optional new refresh token. When present, the old refresh token
+    /// should be replaced — this is called "token rotation" and is a
+    /// security best practice to limit the impact of leaked tokens.
+    pub refresh_token: Option<String>,
+
+    /// The lifetime of the access token in seconds.
+    /// If `None`, the token has no known expiry.
+    pub expires_in: Option<u64>,
+}
+
+/// Errors that can occur during OAuth2 token acquisition.
+#[derive(Debug, thiserror::Error)]
+pub enum OAuthError {
+    #[error("HTTP request to token endpoint failed: {0}")]
+    HttpError(String),
+
+    #[error("Token endpoint returned invalid response: {0}")]
+    InvalidResponse(String),
+
+    #[error("Token endpoint returned error (HTTP {status}): {body}")]
+    TokenEndpointError { status: u16, body: String },
+}
+
+/// Acquire an OAuth2 token by POSTing form-encoded credentials to a token endpoint.
+///
+/// Uses the provided Tower service (typically the inner HTTP client) to make
+/// the request. This ensures token acquisition shares the same transport
+/// configuration (TLS, proxies, connection pool) as regular API requests.
+///
+/// # Arguments
+///
+/// * `inner` - A Tower service that can make HTTP requests. The caller is
+///   responsible for readying this service before calling `acquire_token`.
+/// * `endpoint` - The OAuth2 token endpoint URL.
+/// * `form_body` - The URL-encoded form body (e.g., `grant_type=refresh_token&...`).
+///
+/// # Type Parameters
+///
+/// * `ReqBody` - The request body type. Must be constructible from [`Bytes`]
+///   so we can create the form-encoded POST body.
+/// * `ResBody` - The response body type. Must implement [`Body`] so we can
+///   read and parse the JSON token response.
+pub(crate) async fn acquire_token<S, ReqBody, ResBody>(
+    inner: &mut S,
+    endpoint: &str,
+    form_body: String,
+) -> Result<OAuthTokenResponse, OAuthError>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
+    S::Future: Send,
+    S::Error: fmt::Debug,
+    ReqBody: From<Bytes>,
+    ResBody: Body,
+    ResBody::Data: Buf,
+    ResBody::Error: fmt::Debug,
+{
+    debug!(endpoint = %endpoint, "POSTing to token endpoint");
+
+    let body = ReqBody::from(Bytes::from(form_body));
+    let request = Request::post(endpoint)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body)
+        .map_err(|e| OAuthError::HttpError(format!("failed to build token request: {e}")))?;
+
+    let response = inner
+        .call(request)
+        .await
+        .map_err(|e| OAuthError::HttpError(format!("{e:?}")))?;
+
+    let status = response.status();
+    debug!(status = %status, "token endpoint responded");
+
+    let collected = BodyExt::collect(response.into_body())
+        .await
+        .map_err(|e| OAuthError::HttpError(format!("failed to read token response body: {e:?}")))?;
+    let bytes = collected.to_bytes();
+
+    if !status.is_success() {
+        let body = String::from_utf8_lossy(&bytes).to_string();
+        warn!(status = status.as_u16(), body = %body, "token endpoint returned error");
+        return Err(OAuthError::TokenEndpointError {
+            status: status.as_u16(),
+            body,
+        });
+    }
+
+    let token_response = parse_token_response(&bytes)?;
+    debug!(
+        has_refresh_token = token_response.refresh_token.is_some(),
+        expires_in = ?token_response.expires_in,
+        "token acquired successfully"
+    );
+    Ok(token_response)
+}
+
+/// Parse a JSON token endpoint response into an [`OAuthTokenResponse`].
+fn parse_token_response(body: &[u8]) -> Result<OAuthTokenResponse, OAuthError> {
+    let json: serde_json::Value = serde_json::from_slice(body)
+        .map_err(|e| OAuthError::InvalidResponse(format!("invalid JSON: {e}")))?;
+
+    let access_token = json["access_token"]
+        .as_str()
+        .ok_or_else(|| OAuthError::InvalidResponse("missing access_token field".into()))?
+        .to_string();
+
+    Ok(OAuthTokenResponse {
+        access_token,
+        refresh_token: json["refresh_token"].as_str().map(String::from),
+        expires_in: json["expires_in"].as_u64(),
+    })
+}
+
+/// An in-memory cached OAuth2 access token with optional expiry tracking.
+///
+/// Tokens are cached to avoid making token endpoint requests on every API call.
+/// The middleware checks [`is_expired()`](CachedToken::is_expired) before each
+/// request and only refreshes when the token has expired (or is about to).
+///
+/// # Expiry buffer
+///
+/// When a token response includes `expires_in`, we subtract a 30-second buffer
+/// from the expiry time. This ensures we refresh *before* the token actually
+/// expires, avoiding race conditions where a token expires in-flight.
+#[derive(Debug, Clone)]
+pub struct CachedToken {
+    /// The access token string, suitable for use in an `Authorization: Bearer` header.
+    pub access_token: String,
+
+    /// When the token expires. `None` means the token has no known expiry
+    /// and is treated as valid until the server rejects it.
+    pub expires_at: Option<Instant>,
+}
+
+/// Buffer subtracted from token expiry to account for clock skew and network
+/// latency. We refresh 30 seconds early to avoid using an almost-expired token.
+const TOKEN_EXPIRY_BUFFER: Duration = Duration::from_secs(30);
+
+impl CachedToken {
+    /// Create a new cached token with no known expiry.
+    ///
+    /// This is typically used when loading a pre-existing token from the
+    /// secret store, where we don't have information about when it was
+    /// issued or when it expires.
+    pub fn new(access_token: String) -> Self {
+        CachedToken {
+            access_token,
+            expires_at: None,
+        }
+    }
+
+    /// Create a cached token from an OAuth2 token response.
+    ///
+    /// If the response includes `expires_in`, the expiry time is calculated
+    /// as `now + expires_in - buffer`. The buffer ensures we refresh before
+    /// the token actually expires.
+    pub fn from_response(response: &OAuthTokenResponse) -> Self {
+        let expires_at = response.expires_in.map(|secs| {
+            // saturating_sub prevents underflow if expires_in < buffer
+            Instant::now() + Duration::from_secs(secs).saturating_sub(TOKEN_EXPIRY_BUFFER)
+        });
+
+        CachedToken {
+            access_token: response.access_token.clone(),
+            expires_at,
+        }
+    }
+
+    /// Check if the token has expired (or is about to expire).
+    ///
+    /// Returns `false` if the token has no known expiry — we can't know
+    /// it's expired without expiry information, so we assume it's valid
+    /// and let the server tell us otherwise.
+    pub fn is_expired(&self) -> bool {
+        self.expires_at.is_some_and(|exp| Instant::now() >= exp)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cached_token_without_expiry_is_not_expired() {
+        let token = CachedToken::new("test-token".into());
+        assert!(!token.is_expired());
+    }
+
+    #[test]
+    fn cached_token_with_future_expiry_is_not_expired() {
+        let token = CachedToken {
+            access_token: "test-token".into(),
+            expires_at: Some(Instant::now() + Duration::from_secs(3600)),
+        };
+        assert!(!token.is_expired());
+    }
+
+    #[test]
+    fn cached_token_with_past_expiry_is_expired() {
+        let token = CachedToken {
+            access_token: "test-token".into(),
+            expires_at: Some(Instant::now() - Duration::from_secs(60)),
+        };
+        assert!(token.is_expired());
+    }
+
+    #[test]
+    fn from_response_computes_expiry_with_buffer() {
+        let response = OAuthTokenResponse {
+            access_token: "access".into(),
+            refresh_token: None,
+            expires_in: Some(3600),
+        };
+        let token = CachedToken::from_response(&response);
+
+        // The token should expire roughly at now + 3600 - 30 = now + 3570 seconds
+        assert!(!token.is_expired());
+        assert!(token.expires_at.is_some());
+    }
+
+    #[test]
+    fn from_response_without_expiry_creates_non_expiring_token() {
+        let response = OAuthTokenResponse {
+            access_token: "access".into(),
+            refresh_token: None,
+            expires_in: None,
+        };
+        let token = CachedToken::from_response(&response);
+
+        assert!(!token.is_expired());
+        assert!(token.expires_at.is_none());
+    }
+
+    #[test]
+    fn parse_token_response_extracts_fields() {
+        let json = serde_json::json!({
+            "access_token": "my-token",
+            "refresh_token": "my-refresh",
+            "expires_in": 3600
+        });
+        let bytes = serde_json::to_vec(&json).unwrap();
+        let response = parse_token_response(&bytes).unwrap();
+        assert_eq!(response.access_token, "my-token");
+        assert_eq!(response.refresh_token.as_deref(), Some("my-refresh"));
+        assert_eq!(response.expires_in, Some(3600));
+    }
+
+    #[test]
+    fn parse_token_response_handles_minimal_response() {
+        let json = serde_json::json!({ "access_token": "minimal" });
+        let bytes = serde_json::to_vec(&json).unwrap();
+        let response = parse_token_response(&bytes).unwrap();
+        assert_eq!(response.access_token, "minimal");
+        assert!(response.refresh_token.is_none());
+        assert!(response.expires_in.is_none());
+    }
+
+    #[test]
+    fn parse_token_response_rejects_missing_access_token() {
+        let json = serde_json::json!({ "refresh_token": "oops" });
+        let bytes = serde_json::to_vec(&json).unwrap();
+        let result = parse_token_response(&bytes);
+        assert!(result.is_err());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod client;
 pub mod config;
 pub mod path;
 pub mod secrets;

--- a/src/secrets/keyring.rs
+++ b/src/secrets/keyring.rs
@@ -161,15 +161,21 @@ impl SecretStore for KeyringSecretStore {
                     KEY_SERVICE_ACCOUNT_CLIENT_SECRET,
                     &service_account.client_secret,
                 )?;
-                if let Some(token) = &service_account.access_token {
-                    set_keyring_value(profile_name, KEY_SERVICE_ACCOUNT_ACCESS_TOKEN, token)?;
+                match &service_account.access_token {
+                    Some(token) => {
+                        set_keyring_value(profile_name, KEY_SERVICE_ACCOUNT_ACCESS_TOKEN, token)?;
+                    }
+                    None => try_delete_entry(profile_name, KEY_SERVICE_ACCOUNT_ACCESS_TOKEN),
                 }
-                if let Some(expires_at) = service_account.token_expires_at {
-                    set_keyring_value(
-                        profile_name,
-                        KEY_SERVICE_ACCOUNT_TOKEN_EXPIRES_AT,
-                        &expires_at.to_string(),
-                    )?;
+                match service_account.token_expires_at {
+                    Some(expires_at) => {
+                        set_keyring_value(
+                            profile_name,
+                            KEY_SERVICE_ACCOUNT_TOKEN_EXPIRES_AT,
+                            &expires_at.to_string(),
+                        )?;
+                    }
+                    None => try_delete_entry(profile_name, KEY_SERVICE_ACCOUNT_TOKEN_EXPIRES_AT),
                 }
                 Ok(())
             }

--- a/src/secrets/legacy.rs
+++ b/src/secrets/legacy.rs
@@ -72,10 +72,17 @@ impl SecretStore for LegacySecretStore {
                     try_get_optional_string(&mut profile_table, "service_account_access_token")?
                         .map(|s| s.to_string());
 
+                let token_expires_at = try_get_optional_string(
+                    &mut profile_table,
+                    "service_account_token_expires_at",
+                )?
+                .and_then(|s| s.parse::<u64>().ok());
+
                 Secret::ServiceAccount(ServiceAccount {
                     client_id,
                     client_secret,
                     access_token,
+                    token_expires_at,
                 })
             }
             AuthType::UserAccount => {
@@ -121,9 +128,12 @@ impl SecretStore for LegacySecretStore {
                     service_account.client_secret.into(),
                 );
                 if let Some(token) = service_account.access_token {
+                    profile_table.insert("service_account_access_token".to_string(), token.into());
+                }
+                if let Some(expires_at) = service_account.token_expires_at {
                     profile_table.insert(
-                        "service_account_access_token".to_string(),
-                        token.into(),
+                        "service_account_token_expires_at".to_string(),
+                        expires_at.to_string().into(),
                     );
                 }
             }

--- a/src/secrets/legacy.rs
+++ b/src/secrets/legacy.rs
@@ -68,7 +68,15 @@ impl SecretStore for LegacySecretStore {
                     return Ok(None);
                 };
 
-                Secret::ServiceAccount(ServiceAccount::new(client_id, client_secret))
+                let access_token =
+                    try_get_optional_string(&mut profile_table, "service_account_access_token")?
+                        .map(|s| s.to_string());
+
+                Secret::ServiceAccount(ServiceAccount {
+                    client_id,
+                    client_secret,
+                    access_token,
+                })
             }
             AuthType::UserAccount => {
                 let Some(access_token) =
@@ -112,6 +120,12 @@ impl SecretStore for LegacySecretStore {
                     "client_secret".to_string(),
                     service_account.client_secret.into(),
                 );
+                if let Some(token) = service_account.access_token {
+                    profile_table.insert(
+                        "service_account_access_token".to_string(),
+                        token.into(),
+                    );
+                }
             }
             Secret::UserAccount(user_account) => {
                 profile_table.insert("access_token".to_string(), user_account.access_token.into());

--- a/src/secrets/legacy.rs
+++ b/src/secrets/legacy.rs
@@ -127,14 +127,25 @@ impl SecretStore for LegacySecretStore {
                     "client_secret".to_string(),
                     service_account.client_secret.into(),
                 );
-                if let Some(token) = service_account.access_token {
-                    profile_table.insert("service_account_access_token".to_string(), token.into());
+                match service_account.access_token {
+                    Some(token) => {
+                        profile_table
+                            .insert("service_account_access_token".to_string(), token.into());
+                    }
+                    None => {
+                        profile_table.remove("service_account_access_token");
+                    }
                 }
-                if let Some(expires_at) = service_account.token_expires_at {
-                    profile_table.insert(
-                        "service_account_token_expires_at".to_string(),
-                        expires_at.to_string().into(),
-                    );
+                match service_account.token_expires_at {
+                    Some(expires_at) => {
+                        profile_table.insert(
+                            "service_account_token_expires_at".to_string(),
+                            expires_at.to_string().into(),
+                        );
+                    }
+                    None => {
+                        profile_table.remove("service_account_token_expires_at");
+                    }
                 }
             }
             Secret::UserAccount(user_account) => {

--- a/src/secrets/mod.rs
+++ b/src/secrets/mod.rs
@@ -78,6 +78,9 @@ impl From<ApiKeys> for Secret {
 pub struct ServiceAccount {
     pub client_id: String,
     pub client_secret: String,
+    /// Cached access token. When present, the auth middleware uses it directly
+    /// instead of making a token endpoint request on the first call.
+    pub access_token: Option<String>,
 }
 
 impl ServiceAccount {
@@ -85,6 +88,7 @@ impl ServiceAccount {
         Self {
             client_id,
             client_secret,
+            access_token: None,
         }
     }
 }

--- a/src/secrets/mod.rs
+++ b/src/secrets/mod.rs
@@ -20,7 +20,16 @@ pub enum SecretStoreError {
     Serialization { reason: String },
 }
 
-pub trait SecretStore {
+/// Trait for reading and writing authentication secrets.
+///
+/// The `Send + Sync` supertraits are required because the authentication
+/// middleware stores the secret store behind an `Arc<RwLock<...>>`, which
+/// requires `Send + Sync` for safe sharing across async tasks.
+///
+/// The `#[cfg_attr(test, mockall::automock)]` attribute generates a
+/// `MockSecretStore` type during test compilation for use in unit tests.
+#[cfg_attr(test, mockall::automock)]
+pub trait SecretStore: Send + Sync {
     fn get(
         &self,
         profile_name: &str,

--- a/src/secrets/mod.rs
+++ b/src/secrets/mod.rs
@@ -81,6 +81,10 @@ pub struct ServiceAccount {
     /// Cached access token. When present, the auth middleware uses it directly
     /// instead of making a token endpoint request on the first call.
     pub access_token: Option<String>,
+    /// Unix timestamp (seconds since epoch) at which the cached access token
+    /// should be proactively refreshed (already has the 30-second buffer
+    /// subtracted). `None` if no expiry is known.
+    pub token_expires_at: Option<u64>,
 }
 
 impl ServiceAccount {
@@ -89,6 +93,7 @@ impl ServiceAccount {
             client_id,
             client_secret,
             access_token: None,
+            token_expires_at: None,
         }
     }
 }

--- a/tests/legacy_store.rs
+++ b/tests/legacy_store.rs
@@ -18,7 +18,7 @@ fn legacy_store_get_user_account_profile() {
         "user_account-0987654321".to_string(),
     ));
 
-    let mut legacy_store = LegacySecretStore::new(fixture_path("05-all-credential-types.toml"));
+    let legacy_store = LegacySecretStore::new(fixture_path("05-all-credential-types.toml"));
 
     let actual = legacy_store
         .get("profile_with_user_account", AuthType::UserAccount)
@@ -36,7 +36,7 @@ fn legacy_store_get_api_keys_profile() {
         "api_keys-0987654321".to_string(),
     ));
 
-    let mut legacy_store = LegacySecretStore::new(fixture_path("05-all-credential-types.toml"));
+    let legacy_store = LegacySecretStore::new(fixture_path("05-all-credential-types.toml"));
 
     let actual = legacy_store
         .get("profile_with_api_keys", AuthType::ApiKeys)
@@ -54,7 +54,7 @@ fn legacy_store_get_service_account_profile() {
         "service_account-0987654321".to_string(),
     ));
 
-    let mut legacy_store = LegacySecretStore::new(fixture_path("05-all-credential-types.toml"));
+    let legacy_store = LegacySecretStore::new(fixture_path("05-all-credential-types.toml"));
 
     let actual = legacy_store
         .get("profile_with_service_account", AuthType::ServiceAccount)
@@ -67,7 +67,7 @@ fn legacy_store_get_service_account_profile() {
 
 #[test]
 fn legacy_store_get_profile_not_found() {
-    let mut legacy_store = LegacySecretStore::new(fixture_path("05-all-credential-types.toml"));
+    let legacy_store = LegacySecretStore::new(fixture_path("05-all-credential-types.toml"));
 
     assert!(
         legacy_store

--- a/tests/load_config.rs
+++ b/tests/load_config.rs
@@ -72,6 +72,8 @@ fn all_options_config_profile_with_user_account() {
         project_id: Some("689eebca5ebb720663a2d123".to_string()),
         service: Some(config::Service::Cloud),
         output: Some(config::OutputFormat::Json),
+        ops_manager_url: None,
+        client_id: None,
     };
 
     let actual = config::load_config_from_file(


### PR DESCRIPTION
Implemented a tower authentication layer `AuthenticationLayer`.

See `examples/use_client.rs` for a full example.

The gist is that you can now do this any you'll always have an authenticated client:
```rs
// Build auth layer based on config
let auth_layer = AuthenticationLayer::from_config(&cfg, profile, secret_store).unwrap();
let http_client = /* setup http_client */;

// Build the client service
let mut client = ServiceBuilder::new()
    .layer(auth_layer)
    .layer(DecompressionLayer::new())
    .service(https_client);

// Gen an initialized http client
let ready_client = client.ready().await.unwrap();

// Build the request
let request = Request::builder()
    .method("GET")
    .uri(format!("{}/api/atlas/v2/groups", cfg.base_url()))
    .header("Accept", "application/vnd.atlas.2024-08-05+json")
    .body(Full::<Bytes>::default())
    .unwrap();

// Get the repsonse
let _response = ready_client.call(request).await.unwrap();
```
