### PR TITLE
feat(macos): code signing to eliminate Keychain re-prompts on rebuild

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,24 @@
+# macOS-only: run every freshly built binary through a wrapper that codesigns
+# it with a stable, self-signed identity before executing.
+#
+# Why: macOS keys each Keychain item's access-control list off the *code
+# signature* of the program that touched it. Plain `cargo` builds are ad-hoc
+# signed, and an ad-hoc signature's designated requirement is the binary's
+# content hash — which changes on every rebuild. The Keychain therefore treats
+# each rebuild as a new, untrusted program and re-prompts for permission.
+# Signing with the same certificate + bundle id on every build keeps that
+# requirement stable, so a single "Always Allow" survives rebuilds.
+#
+# See https://github.com/open-source-cooperative/keyring-rs/issues/272 and
+# scripts/codesign-and-run.sh. The wrapper is a safe no-op when no dev identity
+# is installed (e.g. on CI), so it never blocks a build.
+#
+# Both Apple architectures are listed because a target runner only applies to a
+# matching target triple. Invoke cargo from the repository root so the relative
+# script path resolves.
+
+[target.aarch64-apple-darwin]
+runner = ["bash", "scripts/codesign-and-run.sh"]
+
+[target.x86_64-apple-darwin]
+runner = ["bash", "scripts/codesign-and-run.sh"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,8 +10,14 @@
 # requirement stable, so a single "Always Allow" survives rebuilds.
 #
 # See https://github.com/open-source-cooperative/keyring-rs/issues/272 and
-# scripts/codesign-and-run.sh. The wrapper is a safe no-op when no dev identity
-# is installed (e.g. on CI), so it never blocks a build.
+# scripts/codesign-and-run.sh. The wrapper creates the signing identity on first
+# use (interactive terminals only) and is a safe no-op when none is installed on
+# a non-interactive build (e.g. on CI), so it never blocks a build.
+#
+# Why a runner and not build.rs: a build script runs *before* Cargo compiles the
+# crate's binaries, so the artifact to sign does not exist yet, and Cargo has no
+# post-build hook. A target runner is the supported seam for acting on a freshly
+# built binary — it wraps `cargo run`, `cargo test`, and `cargo bench`.
 #
 # Both Apple architectures are listed because a target runner only applies to a
 # matching target triple. Invoke cargo from the repository root so the relative

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,11 @@ jobs:
   test-matrix:
     runs-on: ${{ matrix.os }}
 
+    env:
+      ATLAS_CLI_SIGN_CERT_P12_BASE64: ${{ secrets.MACOS_CODESIGN_P12_BASE64 }}
+      ATLAS_CLI_SIGN_CERT_P12_PASSWORD: ${{ secrets.MACOS_CODESIGN_P12_PASSWORD }}
+      ATLAS_CLI_SIGN_IDENTITY: ${{ vars.MACOS_CODESIGN_IDENTITY }}
+
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
@@ -97,7 +102,10 @@ jobs:
         key: ${{ runner.os }}-${{ matrix.rust }}-cargo-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
           ${{ runner.os }}-${{ matrix.rust }}-cargo-
-
+    - name: Import macOS signing certificate
+      if: runner.os == 'macOS' && env.ATLAS_CLI_SIGN_CERT_P12_BASE64 != ''
+      run: bash scripts/ci-import-signing-cert.sh
+      
     - name: Build
       run: cargo build --verbose
 

--- a/README.md
+++ b/README.md
@@ -104,8 +104,10 @@ runner's keychain is ephemeral and there's no human to re-prompt, so plain
 `cargo build` + `cargo test --lib` run fine unsigned). You only need it if a CI
 step actually exercises the real Keychain.
 
-When you do, sign with a **real code-signing certificate** shipped as an
-encrypted secret. Export it to a `.p12` and base64-encode it once:
+When you do, sign with a **code-signing certificate** shipped as an encrypted
+secret — a real Developer ID/CA cert, or a free self-signed one (the script
+trusts a self-signed cert for you). Export it to a `.p12` and base64-encode it
+once:
 
 ```bash
 base64 -i certificate.p12 | pbcopy   # any code-signing cert: Developer ID, internal CA, or self-signed
@@ -137,7 +139,10 @@ Then add a job-level `env:` and a guarded step to your macOS CI job (e.g.
 [`scripts/ci-import-signing-cert.sh`](scripts/ci-import-signing-cert.sh) imports
 the cert into a dedicated keychain and authorizes `codesign` non-interactively
 (`security set-key-partition-list` — the headless equivalent of clicking *Always
-Allow*). The cargo runner then signs automatically. When the secret is absent —
+Allow*). A self-signed cert is also trusted for code signing automatically (via
+passwordless sudo, which GitHub-hosted runners provide); a cert that chains to a
+trusted root needs no trust step. The cargo runner then signs automatically. When
+the secret is absent —
 including pull requests from forks, which can't read secrets — the step is
 skipped and the suite runs unsigned, so nothing breaks.
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ once:
 base64 -i certificate.p12 | pbcopy   # any code-signing cert: Developer ID, internal CA, or self-signed
 ```
 
+> If you generate the `.p12` yourself with OpenSSL 3, add `-legacy` to the
+> `openssl pkcs12 -export` command (or use macOS's `/usr/bin/openssl`, which is
+> LibreSSL) — otherwise `security import` rejects it on the runner with "MAC
+> verification failed during PKCS12 import".
+
 Then add to the repository:
 
 | Name | Kind | Value |

--- a/README.md
+++ b/README.md
@@ -67,6 +67,34 @@ cargo test
 cargo run --example print_default_profile
 ```
 
+#### macOS: stop the Keychain re-prompting on every rebuild
+
+On macOS the Keychain ties each stored credential to the **code signature** of
+the program that accesses it. Plain `cargo` builds are ad-hoc signed, and an
+ad-hoc signature changes on every rebuild, so macOS treats each rebuild as a new
+program and keeps asking for permission — even after you click *Always Allow*.
+(See [keyring-rs#272](https://github.com/open-source-cooperative/keyring-rs/issues/272).)
+
+To fix it, sign local builds with a stable identity. Run this **once**:
+
+```bash
+./scripts/setup-codesign-identity.sh
+```
+
+It creates a self-signed, code-signing-only dev certificate in your login
+keychain (asking for your login password a single time). After that, the cargo
+runner configured in [`.cargo/config.toml`](.cargo/config.toml) automatically
+signs every binary with the same identity and bundle id before running it:
+
+```bash
+cargo run --example list_clusters --features derive
+```
+
+The first run still prompts once — click **Always Allow**. Because every rebuild
+now carries the same signature, macOS won't ask again. This is a local-dev
+certificate only; it requires no Apple Developer account and is a no-op on other
+platforms and in CI (builds simply run unsigned, as before).
+
 ## License
 
 See [LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,37 @@ as before), so it never blocks a build. If you'd rather provision the identity
 ahead of time, run `./scripts/setup-codesign-identity.sh` directly; set
 `ATLAS_CLI_SIGN_AUTOSETUP=0` to opt out of the automatic setup.
 
+#### Code signing on CI (GitHub Actions)
+
+The interactive setup above can't run on a headless runner — it needs your login
+password to trust a self-signed cert. Most CI doesn't need signing at all (the
+runner's keychain is ephemeral and there's no human to re-prompt, so plain
+`cargo build` + `cargo test --lib` run fine unsigned). You only need it if a CI
+step actually exercises the real Keychain.
+
+When you do, sign with a **real code-signing certificate** shipped as an
+encrypted secret. Export it to a `.p12` and base64-encode it once:
+
+```bash
+base64 -i certificate.p12 | pbcopy   # any code-signing cert: Developer ID, internal CA, or self-signed
+```
+
+Then add to the repository:
+
+| Name | Kind | Value |
+| --- | --- | --- |
+| `MACOS_CODESIGN_P12_BASE64` | secret | the base64 from above |
+| `MACOS_CODESIGN_P12_PASSWORD` | secret | the `.p12` export password |
+| `MACOS_CODESIGN_IDENTITY` | variable | the cert's name, e.g. `Developer ID Application: Your Name (TEAMID)` |
+
+The `test-matrix` job is already wired up: when the secret is present it runs
+[`scripts/ci-import-signing-cert.sh`](scripts/ci-import-signing-cert.sh), which
+imports the cert into a dedicated keychain and authorizes `codesign`
+non-interactively (`security set-key-partition-list` — the headless equivalent
+of clicking *Always Allow*). The cargo runner then signs automatically. When the
+secret is absent — including pull requests from forks, which can't read secrets —
+the step is skipped and the suite runs unsigned, so nothing breaks.
+
 ## License
 
 See [LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -119,13 +119,27 @@ Then add to the repository:
 | `MACOS_CODESIGN_P12_PASSWORD` | secret | the `.p12` export password |
 | `MACOS_CODESIGN_IDENTITY` | variable | the cert's name, e.g. `Developer ID Application: Your Name (TEAMID)` |
 
-The `test-matrix` job is already wired up: when the secret is present it runs
-[`scripts/ci-import-signing-cert.sh`](scripts/ci-import-signing-cert.sh), which
-imports the cert into a dedicated keychain and authorizes `codesign`
-non-interactively (`security set-key-partition-list` — the headless equivalent
-of clicking *Always Allow*). The cargo runner then signs automatically. When the
-secret is absent — including pull requests from forks, which can't read secrets —
-the step is skipped and the suite runs unsigned, so nothing breaks.
+Then add a job-level `env:` and a guarded step to your macOS CI job (e.g.
+`test-matrix` in [`.github/workflows/ci.yml`](.github/workflows/ci.yml)):
+
+```yaml
+    env:
+      ATLAS_CLI_SIGN_CERT_P12_BASE64: ${{ secrets.MACOS_CODESIGN_P12_BASE64 }}
+      ATLAS_CLI_SIGN_CERT_P12_PASSWORD: ${{ secrets.MACOS_CODESIGN_P12_PASSWORD }}
+      ATLAS_CLI_SIGN_IDENTITY: ${{ vars.MACOS_CODESIGN_IDENTITY }}
+    # ...
+    steps:
+    - name: Import macOS signing certificate
+      if: runner.os == 'macOS' && env.ATLAS_CLI_SIGN_CERT_P12_BASE64 != ''
+      run: bash scripts/ci-import-signing-cert.sh
+```
+
+[`scripts/ci-import-signing-cert.sh`](scripts/ci-import-signing-cert.sh) imports
+the cert into a dedicated keychain and authorizes `codesign` non-interactively
+(`security set-key-partition-list` — the headless equivalent of clicking *Always
+Allow*). The cargo runner then signs automatically. When the secret is absent —
+including pull requests from forks, which can't read secrets — the step is
+skipped and the suite runs unsigned, so nothing breaks.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -75,25 +75,26 @@ ad-hoc signature changes on every rebuild, so macOS treats each rebuild as a new
 program and keeps asking for permission — even after you click *Always Allow*.
 (See [keyring-rs#272](https://github.com/open-source-cooperative/keyring-rs/issues/272).)
 
-To fix it, sign local builds with a stable identity. Run this **once**:
-
-```bash
-./scripts/setup-codesign-identity.sh
-```
-
-It creates a self-signed, code-signing-only dev certificate in your login
-keychain (asking for your login password a single time). After that, the cargo
-runner configured in [`.cargo/config.toml`](.cargo/config.toml) automatically
-signs every binary with the same identity and bundle id before running it:
+The fix is to sign local builds with a stable identity, and it is wired to
+happen automatically. The cargo runner in
+[`.cargo/config.toml`](.cargo/config.toml) signs every binary before running it,
+and **creates the signing identity on first use** if it doesn't exist yet — so
+you just build as usual:
 
 ```bash
 cargo run --example list_clusters --features derive
 ```
 
-The first run still prompts once — click **Always Allow**. Because every rebuild
-now carries the same signature, macOS won't ask again. This is a local-dev
-certificate only; it requires no Apple Developer account and is a no-op on other
-platforms and in CI (builds simply run unsigned, as before).
+The first build creates a self-signed, code-signing-only dev certificate in your
+login keychain (asking for your login password once), then signs and runs. Click
+**Always Allow** on the Keychain prompt; because every rebuild now carries the
+same signature, macOS won't ask again.
+
+This is a local-dev certificate only — no Apple Developer account needed. It is a
+no-op on other platforms and on CI (non-interactive builds simply run unsigned,
+as before), so it never blocks a build. If you'd rather provision the identity
+ahead of time, run `./scripts/setup-codesign-identity.sh` directly; set
+`ATLAS_CLI_SIGN_AUTOSETUP=0` to opt out of the automatic setup.
 
 ## License
 

--- a/scripts/ci-import-signing-cert.sh
+++ b/scripts/ci-import-signing-cert.sh
@@ -15,8 +15,11 @@
 #
 #     base64 -i certificate.p12 | pbcopy        # paste into the GH secret
 #
-# (Any code-signing .p12 works: a Developer ID Application cert, an internal-CA
-# cert, or a self-signed one exported from scripts/setup-codesign-identity.sh.)
+# Any code-signing .p12 works. A cert that chains to a trusted root (Developer ID
+# Application, an internal CA) is signed-ready immediately. A self-signed cert is
+# also fine: this script detects that it isn't trusted yet and trusts it for code
+# signing automatically, which needs passwordless sudo (GitHub-hosted runners
+# have it).
 #
 # Required environment (wire these from GitHub Actions secrets/vars):
 #   ATLAS_CLI_SIGN_CERT_P12_BASE64    base64 of the .p12
@@ -55,8 +58,8 @@ KEYCHAIN="${ATLAS_CLI_SIGN_KEYCHAIN:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/atlas-codes
 KC_PASS="${ATLAS_CLI_SIGN_KEYCHAIN_PASSWORD:-$(openssl rand -base64 24)}"
 
 workdir="$(mktemp -d)"
-# The decoded .p12 is private key material; shred it as soon as we're done.
-cleanup() { rm -f "$workdir/cert.p12"; rmdir "$workdir" 2>/dev/null || true; }
+# The decoded .p12 holds private key material; drop the whole workdir on exit.
+cleanup() { rm -rf "$workdir"; }
 trap cleanup EXIT
 
 # Decode via openssl (portable): macOS's BSD `base64` spells decode `-D`, not
@@ -83,11 +86,30 @@ security import "$workdir/cert.p12" -P "$P12_PASS" -k "$KEYCHAIN" \
 security set-key-partition-list -S apple-tool:,apple:,codesign: \
   -s -k "$KC_PASS" "$KEYCHAIN" >/dev/null
 
+# A certificate that chains to a trusted root (Developer ID, an org CA) is
+# already valid for signing. A self-signed certificate is not trusted by
+# default, so `find-identity -v` won't list it until we trust it for code
+# signing — do that automatically when needed. This adjusts the system trust
+# store, so it needs passwordless sudo (GitHub-hosted runners have it; on a
+# self-hosted runner, grant sudo or pre-trust the cert out of band).
 if ! security find-identity -v -p codesigning "$KEYCHAIN" | grep -qF "$IDENTITY"; then
-  echo "error: imported the certificate but found no valid code-signing identity" >&2
-  echo "       matching \"$IDENTITY\". Set ATLAS_CLI_SIGN_IDENTITY to the cert's" >&2
-  echo "       name, and make sure the cert chains to a trusted root (a self-signed" >&2
-  echo "       cert must also be trusted for code signing). Identities present:" >&2
+  echo "note: \"$IDENTITY\" is not a trusted code-signing identity yet — trusting" >&2
+  echo "      it for code signing (expected for a self-signed certificate)." >&2
+  if ! sudo -n true 2>/dev/null; then
+    echo "error: trusting the certificate needs passwordless sudo, which isn't" >&2
+    echo "       available here. Use a cert that chains to a trusted root, or" >&2
+    echo "       pre-trust this one on the runner." >&2
+    exit 1
+  fi
+  security find-certificate -c "$IDENTITY" -p "$KEYCHAIN" >"$workdir/cert.pem"
+  sudo security add-trusted-cert -d -r trustRoot -p codeSign \
+    -k /Library/Keychains/System.keychain "$workdir/cert.pem"
+fi
+
+if ! security find-identity -v -p codesigning "$KEYCHAIN" | grep -qF "$IDENTITY"; then
+  echo "error: imported the certificate but still found no valid code-signing" >&2
+  echo "       identity matching \"$IDENTITY\". Set ATLAS_CLI_SIGN_IDENTITY to the" >&2
+  echo "       certificate's exact name. Identities present:" >&2
   security find-identity -v -p codesigning "$KEYCHAIN" >&2 || true
   exit 1
 fi

--- a/scripts/ci-import-signing-cert.sh
+++ b/scripts/ci-import-signing-cert.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# CI: import a real code-signing identity into a dedicated keychain so the macOS
+# cargo runner (scripts/codesign-and-run.sh) can sign builds non-interactively —
+# no GUI trust dialog and no "Always Allow" click.
+#
+# The local setup script (setup-codesign-identity.sh) is interactive on purpose
+# (it asks for your login password to trust a self-signed cert). That can't run
+# on a headless GitHub Actions runner, so on CI you instead ship a pre-made
+# certificate as an encrypted secret and import it with this script. Run it once
+# early in a macOS job; afterwards `cargo run`/`cargo test`/`cargo bench` sign
+# automatically because the runner finds the identity in the search list.
+#
+# Create the secret once, locally, from your code-signing certificate:
+#
+#     base64 -i certificate.p12 | pbcopy        # paste into the GH secret
+#
+# (Any code-signing .p12 works: a Developer ID Application cert, an internal-CA
+# cert, or a self-signed one exported from scripts/setup-codesign-identity.sh.)
+#
+# Required environment (wire these from GitHub Actions secrets/vars):
+#   ATLAS_CLI_SIGN_CERT_P12_BASE64    base64 of the .p12
+#   ATLAS_CLI_SIGN_CERT_P12_PASSWORD  password the .p12 was exported with
+#   ATLAS_CLI_SIGN_IDENTITY           identity to sign with; must match the cert
+#                                     (its common name, e.g. "Developer ID
+#                                     Application: Name (TEAMID)"). Defaults to
+#                                     the local dev identity name, so set this
+#                                     unless your cert's CN happens to match.
+# Optional:
+#   ATLAS_CLI_SIGN_KEYCHAIN           keychain file to create/use
+#                                     (default: under RUNNER_TEMP/TMPDIR)
+#   ATLAS_CLI_SIGN_KEYCHAIN_PASSWORD  password for that keychain (default: random)
+
+set -euo pipefail
+
+IDENTITY="${ATLAS_CLI_SIGN_IDENTITY:-MongoDB Atlas CLI NG Dev}"
+P12_B64="${ATLAS_CLI_SIGN_CERT_P12_BASE64:-}"
+P12_PASS="${ATLAS_CLI_SIGN_CERT_P12_PASSWORD:-}"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "Code signing only applies on macOS; nothing to do on $(uname -s)."
+  exit 0
+fi
+
+if [[ -z "$P12_B64" ]]; then
+  echo "error: ATLAS_CLI_SIGN_CERT_P12_BASE64 is empty — set it from your CI secret." >&2
+  exit 1
+fi
+
+for tool in security codesign openssl; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "error: '$tool' not found on PATH." >&2; exit 1; }
+done
+
+KEYCHAIN="${ATLAS_CLI_SIGN_KEYCHAIN:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/atlas-codesign.keychain-db}"
+KC_PASS="${ATLAS_CLI_SIGN_KEYCHAIN_PASSWORD:-$(openssl rand -base64 24)}"
+
+workdir="$(mktemp -d)"
+# The decoded .p12 is private key material; shred it as soon as we're done.
+cleanup() { rm -f "$workdir/cert.p12"; rmdir "$workdir" 2>/dev/null || true; }
+trap cleanup EXIT
+
+# Decode via openssl (portable): macOS's BSD `base64` spells decode `-D`, not
+# `--decode`, and `-A` accepts the secret whether it's one line or wrapped.
+printf '%s' "$P12_B64" | openssl base64 -d -A >"$workdir/cert.p12"
+
+# Dedicated, unlocked keychain that won't auto-lock mid-job. Recreate it so
+# re-runs start from a clean slate, then add it to the search list so
+# find-identity/codesign (which the runner calls without naming a keychain) see
+# the imported identity.
+security delete-keychain "$KEYCHAIN" 2>/dev/null || true
+security create-keychain -p "$KC_PASS" "$KEYCHAIN"
+security set-keychain-settings -lut 21600 "$KEYCHAIN"
+security unlock-keychain -p "$KC_PASS" "$KEYCHAIN"
+existing_keychains="$(security list-keychains -d user | tr -d '"')"
+# shellcheck disable=SC2086 # intentional word-splitting of the keychain list
+security list-keychains -d user -s "$KEYCHAIN" $existing_keychains
+
+# Import the identity, authorise codesign/security to use the private key, then
+# set the partition list so signing never pops a prompt — the headless
+# equivalent of clicking "Always Allow", and the step CI setups usually miss.
+security import "$workdir/cert.p12" -P "$P12_PASS" -k "$KEYCHAIN" \
+  -T /usr/bin/codesign -T /usr/bin/security
+security set-key-partition-list -S apple-tool:,apple:,codesign: \
+  -s -k "$KC_PASS" "$KEYCHAIN" >/dev/null
+
+if ! security find-identity -v -p codesigning "$KEYCHAIN" | grep -qF "$IDENTITY"; then
+  echo "error: imported the certificate but found no valid code-signing identity" >&2
+  echo "       matching \"$IDENTITY\". Set ATLAS_CLI_SIGN_IDENTITY to the cert's" >&2
+  echo "       name, and make sure the cert chains to a trusted root (a self-signed" >&2
+  echo "       cert must also be trusted for code signing). Identities present:" >&2
+  security find-identity -v -p codesigning "$KEYCHAIN" >&2 || true
+  exit 1
+fi
+
+echo "Code-signing identity \"$IDENTITY\" imported into $KEYCHAIN."
+echo "cargo run/test/bench on this runner will now sign automatically."

--- a/scripts/codesign-and-run.sh
+++ b/scripts/codesign-and-run.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 #
 # Cargo target runner for macOS: codesign a freshly built binary with a stable,
-# self-signed identity, then exec it.
+# self-signed identity, then exec it. If that identity does not exist yet it is
+# created on first use, so signing "just works" with no separate setup step.
 #
 # WHY THIS EXISTS
 # ---------------
@@ -24,11 +25,16 @@
 # HOW IT'S WIRED
 # --------------
 # .cargo/config.toml registers this as the macOS target runner, so `cargo run
-# --example ...` (and `cargo run`, `cargo test`) sign automatically. It is a
-# safe no-op when no dev identity is installed (e.g. on CI or before the
-# one-time setup), so it never blocks a build.
+# --example ...` (and `cargo run`, `cargo test`) sign automatically. A runner is
+# the right seam here because Cargo has no post-build hook and a build.rs runs
+# *before* the binary is compiled — see .cargo/config.toml for that rationale.
 #
-# Run scripts/setup-codesign-identity.sh once to create the identity.
+# On the first build where the signing identity is missing, this calls
+# scripts/setup-codesign-identity.sh to create it (one login-password prompt).
+# That only happens on an interactive terminal, so CI and other non-interactive
+# builds stay a safe no-op and run unsigned — nothing ever blocks a build. Set
+# ATLAS_CLI_SIGN_AUTOSETUP=0 to skip auto-setup and sign only when an identity
+# already exists.
 
 set -euo pipefail
 
@@ -38,6 +44,8 @@ set -euo pipefail
 IDENTITY="${ATLAS_CLI_SIGN_IDENTITY:-MongoDB Atlas CLI NG Dev}"
 BUNDLE_ID="${ATLAS_CLI_SIGN_BUNDLE_ID:-com.mongodb.atlas-cli-ng.dev}"
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 if [[ $# -lt 1 ]]; then
   echo "usage: $0 <binary> [args...]" >&2
   exit 64
@@ -46,20 +54,33 @@ fi
 BIN="$1"
 shift
 
+identity_present() {
+  security find-identity -v -p codesigning 2>/dev/null | grep -qF "$IDENTITY"
+}
+
 sign() {
   # Only meaningful on macOS with the codesign toolchain available.
   [[ "$(uname -s)" == "Darwin" ]] || return 0
   command -v codesign >/dev/null 2>&1 || return 0
   command -v security >/dev/null 2>&1 || return 0
 
-  if ! security find-identity -v -p codesigning 2>/dev/null | grep -qF "$IDENTITY"; then
-    # No dev identity installed: run unsigned so CI / first-time users are not
-    # blocked. Only nudge on an interactive terminal to keep CI logs clean.
-    if [[ -t 2 ]]; then
-      echo "note: code-signing identity \"$IDENTITY\" not found — running unsigned." >&2
-      echo "      run scripts/setup-codesign-identity.sh once to stop Keychain re-prompts." >&2
+  if ! identity_present; then
+    # Create the identity on demand, but only when a human is present to answer
+    # the one-time trust/password prompt. On CI or any non-interactive build we
+    # leave it alone and run unsigned, so nothing blocks.
+    if [[ -t 2 && "${ATLAS_CLI_SIGN_AUTOSETUP:-1}" != "0" \
+          && -x "$SCRIPT_DIR/setup-codesign-identity.sh" ]]; then
+      echo "note: code-signing identity \"$IDENTITY\" not found — setting it up once…" >&2
+      # Route setup output to stderr so it never lands on the program's stdout,
+      # and don't let a declined/failed setup abort the build (we just run
+      # unsigned in that case).
+      ATLAS_CLI_SIGN_QUIET=1 "$SCRIPT_DIR/setup-codesign-identity.sh" >&2 || true
     fi
-    return 0
+
+    if ! identity_present; then
+      [[ -t 2 ]] && echo "note: running \"$BIN\" unsigned; Keychain may re-prompt." >&2
+      return 0
+    fi
   fi
 
   if ! codesign --force --sign "$IDENTITY" --identifier "$BUNDLE_ID" \

--- a/scripts/codesign-and-run.sh
+++ b/scripts/codesign-and-run.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Cargo target runner for macOS: codesign a freshly built binary with a stable,
+# self-signed identity, then exec it.
+#
+# WHY THIS EXISTS
+# ---------------
+# macOS stores Keychain credentials with an access-control list (ACL) keyed off
+# the *code signature* of the program that created/accessed the item. A normal
+# `cargo run`/`cargo build` is ad-hoc signed, and an ad-hoc signature's
+# "designated requirement" is the binary's content hash (cdhash). That hash
+# changes on every rebuild, so the Keychain treats each rebuild as a brand-new,
+# untrusted program and re-prompts:
+#
+#     "<binary> wants to use your confidential information stored in
+#      "atlascli_default" in your keychain."
+#
+# Signing every build with the *same* certificate and the *same* bundle
+# identifier keeps the designated requirement stable across rebuilds, so a
+# single "Always Allow" survives future rebuilds and the prompts stop.
+#
+# See https://github.com/open-source-cooperative/keyring-rs/issues/272
+#
+# HOW IT'S WIRED
+# --------------
+# .cargo/config.toml registers this as the macOS target runner, so `cargo run
+# --example ...` (and `cargo run`, `cargo test`) sign automatically. It is a
+# safe no-op when no dev identity is installed (e.g. on CI or before the
+# one-time setup), so it never blocks a build.
+#
+# Run scripts/setup-codesign-identity.sh once to create the identity.
+
+set -euo pipefail
+
+# Shared with scripts/setup-codesign-identity.sh. Override via the environment
+# if you want different values, but keep them stable over time — changing
+# either invalidates the Keychain ACL and triggers a fresh prompt.
+IDENTITY="${ATLAS_CLI_SIGN_IDENTITY:-MongoDB Atlas CLI NG Dev}"
+BUNDLE_ID="${ATLAS_CLI_SIGN_BUNDLE_ID:-com.mongodb.atlas-cli-ng.dev}"
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <binary> [args...]" >&2
+  exit 64
+fi
+
+BIN="$1"
+shift
+
+sign() {
+  # Only meaningful on macOS with the codesign toolchain available.
+  [[ "$(uname -s)" == "Darwin" ]] || return 0
+  command -v codesign >/dev/null 2>&1 || return 0
+  command -v security >/dev/null 2>&1 || return 0
+
+  if ! security find-identity -v -p codesigning 2>/dev/null | grep -qF "$IDENTITY"; then
+    # No dev identity installed: run unsigned so CI / first-time users are not
+    # blocked. Only nudge on an interactive terminal to keep CI logs clean.
+    if [[ -t 2 ]]; then
+      echo "note: code-signing identity \"$IDENTITY\" not found — running unsigned." >&2
+      echo "      run scripts/setup-codesign-identity.sh once to stop Keychain re-prompts." >&2
+    fi
+    return 0
+  fi
+
+  if ! codesign --force --sign "$IDENTITY" --identifier "$BUNDLE_ID" \
+      --timestamp=none "$BIN" >/dev/null 2>&1; then
+    echo "warning: codesign failed for $BIN — running unsigned (Keychain may re-prompt)." >&2
+  fi
+}
+
+sign
+exec "$BIN" "$@"

--- a/scripts/setup-codesign-identity.sh
+++ b/scripts/setup-codesign-identity.sh
@@ -43,6 +43,11 @@ fi
 
 echo "Creating self-signed code-signing identity \"$IDENTITY\"…"
 
+# We only get here when no *valid* identity exists (checked above). Remove any
+# earlier untrusted or half-imported copies of this name so repeated runs can
+# never accumulate duplicates in the keychain.
+while security delete-identity -c "$IDENTITY" >/dev/null 2>&1; do :; done
+
 workdir="$(mktemp -d)"
 cleanup() { rm -rf "$workdir"; }
 trap cleanup EXIT
@@ -67,7 +72,16 @@ openssl req -x509 -newkey rsa:2048 -nodes -days 3650 \
   -keyout "$workdir/key.pem" -out "$workdir/cert.pem" \
   -config "$workdir/req.cnf" >/dev/null 2>&1
 
-openssl pkcs12 -export -inkey "$workdir/key.pem" -in "$workdir/cert.pem" \
+# OpenSSL 3 defaults to a PKCS#12 MAC/cipher that macOS's `security import`
+# rejects ("MAC verification failed during PKCS12 import (wrong password?)").
+# -legacy restores the algorithms Apple accepts; LibreSSL (/usr/bin/openssl) and
+# OpenSSL 1.x neither need nor recognize the flag.
+p12_legacy=
+if openssl version 2>/dev/null | grep -q '^OpenSSL 3'; then
+  p12_legacy=-legacy
+fi
+# shellcheck disable=SC2086 # $p12_legacy is a single optional flag (or empty)
+openssl pkcs12 -export $p12_legacy -inkey "$workdir/key.pem" -in "$workdir/cert.pem" \
   -name "$IDENTITY" -out "$workdir/identity.p12" -passout pass: >/dev/null 2>&1
 
 # Import the key + cert and grant codesign access to the private key up front,

--- a/scripts/setup-codesign-identity.sh
+++ b/scripts/setup-codesign-identity.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# One-time setup: create a stable, self-signed code-signing identity used to
+# sign local example/CLI builds, so macOS stops re-prompting for Keychain
+# access on every rebuild.
+#
+# Background and the runner that uses this identity live in
+# scripts/codesign-and-run.sh and
+# https://github.com/open-source-cooperative/keyring-rs/issues/272
+#
+# Safe to re-run: it does nothing if the identity already exists. The only
+# expected prompt is a single request for your login password when the
+# certificate is marked trusted for code signing.
+
+set -euo pipefail
+
+# Must match scripts/codesign-and-run.sh (both read the same env vars).
+IDENTITY="${ATLAS_CLI_SIGN_IDENTITY:-MongoDB Atlas CLI NG Dev}"
+KEYCHAIN="${ATLAS_CLI_SIGN_KEYCHAIN:-$HOME/Library/Keychains/login.keychain-db}"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "This setup is only needed on macOS; nothing to do on $(uname -s)."
+  exit 0
+fi
+
+for tool in security codesign openssl; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "error: required tool '$tool' not found on PATH." >&2
+    exit 1
+  fi
+done
+
+if security find-identity -v -p codesigning 2>/dev/null | grep -qF "$IDENTITY"; then
+  echo "Code-signing identity \"$IDENTITY\" already exists — nothing to do."
+  exit 0
+fi
+
+echo "Creating self-signed code-signing identity \"$IDENTITY\"…"
+
+workdir="$(mktemp -d)"
+cleanup() { rm -rf "$workdir"; }
+trap cleanup EXIT
+
+# Self-signed leaf certificate marked for code signing. Written as a config
+# file (rather than -addext) so it works with both OpenSSL and the LibreSSL
+# that ships with macOS.
+cat >"$workdir/req.cnf" <<EOF
+[ req ]
+distinguished_name = dn
+x509_extensions    = ext
+prompt             = no
+[ dn ]
+CN = $IDENTITY
+[ ext ]
+basicConstraints   = critical, CA:false
+keyUsage           = critical, digitalSignature
+extendedKeyUsage   = critical, codeSigning
+EOF
+
+openssl req -x509 -newkey rsa:2048 -nodes -days 3650 \
+  -keyout "$workdir/key.pem" -out "$workdir/cert.pem" \
+  -config "$workdir/req.cnf" >/dev/null 2>&1
+
+openssl pkcs12 -export -inkey "$workdir/key.pem" -in "$workdir/cert.pem" \
+  -name "$IDENTITY" -out "$workdir/identity.p12" -passout pass: >/dev/null 2>&1
+
+# Import the key + cert and grant codesign access to the private key up front,
+# so later signing does not pop a Keychain prompt of its own.
+security import "$workdir/identity.p12" -k "$KEYCHAIN" -P "" \
+  -T /usr/bin/codesign -T /usr/bin/security >/dev/null
+
+# Trust the cert for code signing so `find-identity -v` and `codesign` accept
+# it. This adjusts user trust settings and asks for your login password once —
+# the only expected prompt.
+echo "Marking the certificate trusted for code signing (you may be asked for"
+echo "your login password once)…"
+security add-trusted-cert -p codeSign -k "$KEYCHAIN" "$workdir/cert.pem" ||
+  echo "warning: could not set trust automatically; see the note below." >&2
+
+if security find-identity -v -p codesigning 2>/dev/null | grep -qF "$IDENTITY"; then
+  cat <<EOF
+
+Done — "$IDENTITY" is ready.
+
+Building through cargo now signs automatically, e.g.:
+
+    cargo run --example list_clusters --features derive
+
+The first run still prompts once — click "Always Allow". Because every rebuild
+now carries the same signature, macOS will not ask again.
+EOF
+else
+  cat <<EOF
+
+The certificate was created but is not yet a valid code-signing identity,
+which usually means the trust step did not complete. Finish it in Keychain
+Access:
+
+  1. Open "Keychain Access" → "login" keychain → "My Certificates".
+  2. Double-click the "$IDENTITY" certificate.
+  3. Expand "Trust", set "Code Signing" to "Always Trust", then close
+     (you'll be asked for your password).
+
+Then re-run this script to verify.
+EOF
+  exit 1
+fi

--- a/scripts/setup-codesign-identity.sh
+++ b/scripts/setup-codesign-identity.sh
@@ -72,22 +72,15 @@ openssl req -x509 -newkey rsa:2048 -nodes -days 3650 \
   -keyout "$workdir/key.pem" -out "$workdir/cert.pem" \
   -config "$workdir/req.cnf" >/dev/null 2>&1
 
-# OpenSSL 3 defaults to a PKCS#12 MAC/cipher that macOS's `security import`
-# rejects ("MAC verification failed during PKCS12 import (wrong password?)").
-# -legacy restores the algorithms Apple accepts; LibreSSL (/usr/bin/openssl) and
-# OpenSSL 1.x neither need nor recognize the flag.
-p12_legacy=
-if openssl version 2>/dev/null | grep -q '^OpenSSL 3'; then
-  p12_legacy=-legacy
-fi
-# shellcheck disable=SC2086 # $p12_legacy is a single optional flag (or empty)
-openssl pkcs12 -export $p12_legacy -inkey "$workdir/key.pem" -in "$workdir/cert.pem" \
-  -name "$IDENTITY" -out "$workdir/identity.p12" -passout pass: >/dev/null 2>&1
-
-# Import the key + cert and grant codesign access to the private key up front,
-# so later signing does not pop a Keychain prompt of its own.
-security import "$workdir/identity.p12" -k "$KEYCHAIN" -P "" \
-  -T /usr/bin/codesign -T /usr/bin/security >/dev/null
+# Import the private key and certificate as separate PEM files instead of
+# bundling them into a PKCS#12. macOS forms an identity from any certificate
+# whose private key is already in the keychain, and this avoids the whole class
+# of "MAC verification failed during PKCS12 import" errors — both OpenSSL 3's
+# newer PKCS#12 MAC/cipher defaults and the empty-password MAC encoding that
+# Apple's importer rejects. -T grants codesign/security access to the key up
+# front so signing doesn't pop its own Keychain prompt later.
+security import "$workdir/key.pem"  -k "$KEYCHAIN" -T /usr/bin/codesign -T /usr/bin/security
+security import "$workdir/cert.pem" -k "$KEYCHAIN"
 
 # Trust the cert for code signing so `find-identity -v` and `codesign` accept
 # it. This adjusts user trust settings and asks for your login password once —

--- a/scripts/setup-codesign-identity.sh
+++ b/scripts/setup-codesign-identity.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 #
-# One-time setup: create a stable, self-signed code-signing identity used to
-# sign local example/CLI builds, so macOS stops re-prompting for Keychain
-# access on every rebuild.
+# Create a stable, self-signed code-signing identity used to sign local
+# example/CLI builds, so macOS stops re-prompting for Keychain access on every
+# rebuild.
+#
+# You normally don't need to run this by hand: the cargo runner
+# (scripts/codesign-and-run.sh) calls it automatically the first time it needs
+# the identity. Run it directly only if you want to provision the identity ahead
+# of time. Either way the result is the same.
 #
 # Background and the runner that uses this identity live in
 # scripts/codesign-and-run.sh and
@@ -10,7 +15,8 @@
 #
 # Safe to re-run: it does nothing if the identity already exists. The only
 # expected prompt is a single request for your login password when the
-# certificate is marked trusted for code signing.
+# certificate is marked trusted for code signing. Set ATLAS_CLI_SIGN_QUIET=1 to
+# suppress the closing tutorial (the runner sets this when it calls us).
 
 set -euo pipefail
 
@@ -78,7 +84,10 @@ security add-trusted-cert -p codeSign -k "$KEYCHAIN" "$workdir/cert.pem" ||
   echo "warning: could not set trust automatically; see the note below." >&2
 
 if security find-identity -v -p codesigning 2>/dev/null | grep -qF "$IDENTITY"; then
-  cat <<EOF
+  if [[ -n "${ATLAS_CLI_SIGN_QUIET:-}" ]]; then
+    echo "Code-signing identity \"$IDENTITY\" is ready."
+  else
+    cat <<EOF
 
 Done — "$IDENTITY" is ready.
 
@@ -89,8 +98,9 @@ Building through cargo now signs automatically, e.g.:
 The first run still prompts once — click "Always Allow". Because every rebuild
 now carries the same signature, macOS will not ask again.
 EOF
+  fi
 else
-  cat <<EOF
+  cat >&2 <<EOF
 
 The certificate was created but is not yet a valid code-signing identity,
 which usually means the trust step did not complete. Finish it in Keychain

--- a/src/secrets/keyring.rs
+++ b/src/secrets/keyring.rs
@@ -15,10 +15,10 @@
 //! the service/property names below are unchanged.
 //!
 //! The fix lives in the build tooling, not here: changing the names below would
-//! only orphan existing secrets. `scripts/setup-codesign-identity.sh` creates a
-//! stable self-signed dev identity once, and the macOS cargo runner wired up in
-//! `.cargo/config.toml` (`scripts/codesign-and-run.sh`) signs every build with
-//! it, so a single "Always Allow" survives rebuilds.
+//! only orphan existing secrets. The macOS cargo runner wired up in
+//! `.cargo/config.toml` (`scripts/codesign-and-run.sh`) signs every build with a
+//! stable self-signed dev identity — creating that identity on first use — so a
+//! single "Always Allow" survives rebuilds.
 //!
 //! See <https://github.com/open-source-cooperative/keyring-rs/issues/272>.
 

--- a/src/secrets/keyring.rs
+++ b/src/secrets/keyring.rs
@@ -1,3 +1,27 @@
+//! OS keychain-backed secret store.
+//!
+//! Secrets are keyed by a stable service name (`atlascli_<profile>`, see
+//! [`build_service_name`]) plus a property name, so the same credential items
+//! are reused across runs.
+//!
+//! ## macOS: permission re-prompts after every rebuild
+//!
+//! On macOS the Keychain additionally guards each item with an access-control
+//! list keyed off the *code signature* of the program that accesses it. Plain
+//! `cargo` builds are ad-hoc signed, and an ad-hoc signature's designated
+//! requirement is the binary's content hash — which changes on every rebuild.
+//! macOS therefore treats each rebuild as a new, untrusted program and
+//! re-prompts ("… wants to use your confidential information …"), even though
+//! the service/property names below are unchanged.
+//!
+//! The fix lives in the build tooling, not here: changing the names below would
+//! only orphan existing secrets. `scripts/setup-codesign-identity.sh` creates a
+//! stable self-signed dev identity once, and the macOS cargo runner wired up in
+//! `.cargo/config.toml` (`scripts/codesign-and-run.sh`) signs every build with
+//! it, so a single "Always Allow" survives rebuilds.
+//!
+//! See <https://github.com/open-source-cooperative/keyring-rs/issues/272>.
+
 use keyring::Entry;
 
 use super::{ApiKeys, Secret, SecretStore, SecretStoreError, ServiceAccount, UserAccount};
@@ -28,6 +52,9 @@ impl KeyringSecretStore {
     }
 }
 
+/// Keychain service name for a profile. Keep this format stable: changing it
+/// orphans every previously stored secret. See the module docs for the macOS
+/// re-prompt behavior, which depends on code signing rather than this name.
 fn build_service_name(profile_name: &str) -> String {
     format!("atlascli_{}", profile_name)
 }


### PR DESCRIPTION
## Summary

This change implements automatic code signing for macOS builds to prevent the Keychain from re-prompting for credentials on every rebuild. The solution signs binaries with a stable, self-signed development identity, keeping the code signature constant across rebuilds so the Keychain ACL remains valid.

## Key Changes

- **`.cargo/config.toml`** (new): Registers `scripts/codesign-and-run.sh` as the target runner for both Apple architectures (`aarch64-apple-darwin` and `x86_64-apple-darwin`), so every binary is signed before execution.

- **`scripts/codesign-and-run.sh`** (new): Cargo target runner that:
  - Signs freshly built binaries with a stable identity and bundle ID
  - Creates the signing identity on first use (interactive terminals only)
  - Gracefully degrades to unsigned execution on CI and non-interactive builds
  - Respects `ATLAS_CLI_SIGN_AUTOSETUP` to allow opting out of automatic setup

- **`scripts/setup-codesign-identity.sh`** (new): Creates a self-signed, code-signing-only dev certificate in the login keychain:
  - Generates a 2048-bit RSA certificate valid for 10 years
  - Imports it with proper Keychain ACLs for `codesign` and `security` tools
  - Trusts the certificate for code signing (requires one login password prompt)
  - Safe to re-run; exits early if identity already exists

- **`scripts/ci-import-signing-cert.sh`** (new): CI-specific certificate import for GitHub Actions:
  - Decodes a base64-encoded `.p12` certificate from secrets
  - Creates a dedicated, unlocked keychain for the job
  - Imports the certificate and sets partition lists for non-interactive signing
  - Automatically trusts self-signed certificates via passwordless sudo
  - Supports both Developer ID certificates and self-signed certs

- **`README.md`**: Added comprehensive documentation covering:
  - Why Keychain re-prompts occur (ad-hoc signature changes on every rebuild)
  - How the automatic local setup works
  - How to configure code signing on CI with GitHub Actions secrets/variables
  - Instructions for exporting and encoding certificates

- **`.github/workflows/ci.yml`**: Updated the `test-matrix` job to:
  - Wire code-signing secrets and variables from GitHub
  - Run the certificate import step on macOS when secrets are present
  - Gracefully skip signing when secrets are absent (e.g., fork PRs)

- **`src/secrets/keyring.rs`**: Added module documentation explaining:
  - Why the Keychain re-prompts on macOS after rebuilds
  - How the code signing solution in `.cargo/config.toml` fixes it
  - Reference to the upstream keyring-rs issue

## Implementation Details

- The solution is **platform-aware**: it's a no-op on non-macOS platforms and on non-interactive builds (CI without secrets), so it never blocks a build.
- **Local development** uses a self-signed certificate created on first use, requiring only one login password prompt.
- **CI** uses a pre-made certificate shipped as an encrypted secret, with automatic trust setup for self-signed certs via passwordless sudo.
- The signing identity and bundle ID are configurable via environment variables (`ATLAS_CLI_SIGN_IDENTITY`, `ATLAS_CLI_SIGN_BUNDLE_ID`) to support different setups.
- The runner approach was chosen over `build.rs` because build scripts run before compilation, so the binary to sign doesn't exist yet.

Fixes the Keychain re-prompting issue described in [keyring-rs#272](https://github.com/open-source-cooperative/keyring-rs/issues/272).

https://claude.ai/code/session_01WU1VFafWTQ5EyZuL56CAJf